### PR TITLE
ci: only deploy on functional changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,13 @@ name: CI
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "src/**"
+      - "public/**"
+      - "scripts/**"
+      - "bunfig.toml"
+      - "package.json"
+      - "bun.lock"
   pull_request:
 
 jobs:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,6 +2,8 @@
 
 CI/CD runs through GitHub Actions (`.github/workflows/ci.yml`, `deploy.yml`, `rollback.yml`). On every push to `master` that passes CI, the app is built (`bun run build`, static files only — no container, no runtime dependency on the server beyond a web server able to serve static files) and uploaded to a new release directory on the production server. No Docker: this is a pure static site, so there's nothing to run on the server at all.
 
+Deploy is chained off CI's `workflow_run` completing, so it only fires for pushes CI actually ran for. CI's `push` trigger is restricted to paths that affect the built app (`src/**`, `public/**`, `scripts/**`, `bunfig.toml`, `package.json`, `bun.lock`) — changes limited to docs, tests, or CI workflows themselves don't trigger a deploy. PRs still run CI unconditionally, for visibility.
+
 ## How it works
 
 - Each deploy builds `build/` on the GitHub Actions runner and `rsync`s its **contents directly** into `<deploy_path>/releases/<commit-sha>/` on the server — a release directory holds only the built files, nothing else.


### PR DESCRIPTION
## Summary
- Replaces CI's `paths-ignore: ["**.md"]` with a positive `paths:` allowlist: `src/**`, `public/**`, `scripts/**`, `bunfig.toml`, `package.json`, `bun.lock`
- Deploy is chained off CI's `workflow_run` completing, so this now also gates deploy — pushes touching only tests, docs, or `.github/**` no longer trigger a rebuild+redeploy (this is what happened with the shipit-removal PR: deleting `shipitfile.js` + devDependencies shouldn't have redeployed, and now it wouldn't)
- PRs are unaffected (still run CI unconditionally, for visibility)

**Known residual gap** (discussed and accepted): package.json/bun.lock changes still trigger deploy even when only `devDependencies` change, since GitHub Actions path filters see file paths, not diff content — narrowing further would need a content-aware check step, which adds real fragility for a corner case that's harmless when it does happen (redeploying an unchanged build).

## Test plan
- YAML validated (`js-yaml` load)
- Will confirm on next deploy-relevant push (CI + Deploy run) vs a docs/test-only push (neither runs)