### PR TITLE
refactor: convert class components to function components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useEffect } from "react";
 
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { connect } from "react-redux";
@@ -11,39 +11,36 @@ import { FlashMessage } from "Core/components/FlashMessage/FlashMessage";
 import { Loader } from "Core/components/Loader/Loader";
 import { AuthRouter } from "Auth/router";
 
-class App extends Component {
-  componentDidMount() {
+function App({ isAuthenticated, loading, showFlash }) {
+  useEffect(() => {
     if (
-      !this.props.isAuthenticated &&
+      !isAuthenticated &&
       !/^\/auth\/(log|sign)-in/.test(window.location.pathname)
     ) {
       window.location.replace("/auth/log-in");
     }
+  }, [isAuthenticated]);
+
+  let className = "main-container";
+  if (loading) {
+    className = `${className} ${className}--hidden`;
   }
 
-  render() {
-    const { loading, showFlash } = this.props;
-    let className = "main-container";
-    if (loading) {
-      className = `${className} ${className}--hidden`;
-    }
-
-    return (
-      <>
-        {showFlash && <FlashMessage />}
-        <div className={className}>
-          <BrowserRouter>
-            <Routes>
-              <Route exact path="/" element={<Home />} />
-              <Route path="movies/*" element={<MovieRouter />} />
-              <Route path="auth/*" element={<AuthRouter />} />
-            </Routes>
-          </BrowserRouter>
-        </div>
-        <Loader />
-      </>
-    );
-  }
+  return (
+    <>
+      {showFlash && <FlashMessage />}
+      <div className={className}>
+        <BrowserRouter>
+          <Routes>
+            <Route exact path="/" element={<Home />} />
+            <Route path="movies/*" element={<MovieRouter />} />
+            <Route path="auth/*" element={<AuthRouter />} />
+          </Routes>
+        </BrowserRouter>
+      </div>
+      <Loader />
+    </>
+  );
 }
 
 const mapStateToProps = (state) => {

--- a/src/Format/Item/Format.js
+++ b/src/Format/Item/Format.js
@@ -1,19 +1,13 @@
-import React, { Component } from "react";
+import React from "react";
 
 import "./Format.css";
 
 const baseUrl = process.env.REACT_APP_API_URL;
 
-class Format extends Component {
-  render() {
-    return (
-      <img
-        src={`${baseUrl}/assets/${this.props.logo}`}
-        className="format"
-        alt={this.props.name}
-      />
-    );
-  }
+function Format({ logo, name }) {
+  return (
+    <img src={`${baseUrl}/assets/${logo}`} className="format" alt={name} />
+  );
 }
 
 export default Format;

--- a/src/Format/List/FormatList.js
+++ b/src/Format/List/FormatList.js
@@ -1,21 +1,19 @@
-import React, { Component } from "react";
+import React from "react";
 
 import "./FormatList.css";
 
 import { Format } from "../";
 
-class FormatList extends Component {
-  render() {
-    return (
-      <div className="format-list">
-        {this.props.formats.map(format => {
-          return (
-            <Format key={format.id} label={format.name} logo={format.logo} />
-          );
-        })}
-      </div>
-    );
-  }
+function FormatList({ formats }) {
+  return (
+    <div className="format-list">
+      {formats.map((format) => {
+        return (
+          <Format key={format.id} label={format.name} logo={format.logo} />
+        );
+      })}
+    </div>
+  );
 }
 
 export default FormatList;

--- a/src/Movie/Form/CSVInput.js
+++ b/src/Movie/Form/CSVInput.js
@@ -1,25 +1,23 @@
-import React, { Component } from "react";
+import React from "react";
 
-class CSVInput extends Component {
-  onChangeHandler(reduxFormOnChangeHandler) {
-    return event => {
-      const file = event.target.files[0];
-      reduxFormOnChangeHandler(file);
-    };
-  }
+function onChangeHandler(reduxFormOnChangeHandler) {
+  return (event) => {
+    const file = event.target.files[0];
+    reduxFormOnChangeHandler(file);
+  };
+}
 
-  render() {
-    const { input } = this.props;
-    delete input.value;
-    return (
-      <input
-        type="file"
-        {...input}
-        onChange={this.onChangeHandler(input.onChange)}
-        accept=".csv"
-      />
-    );
-  }
+function CSVInput({ input }) {
+  // eslint-disable-next-line no-unused-vars
+  const { value, ...inputWithoutValue } = input;
+  return (
+    <input
+      type="file"
+      {...inputWithoutValue}
+      onChange={onChangeHandler(input.onChange)}
+      accept=".csv"
+    />
+  );
 }
 
 export default CSVInput;

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { Provider } from "react-redux";
 
 import { IntlProvider } from "react-intl";
@@ -8,14 +8,12 @@ import store from "./configureStore";
 import App from "./App";
 import "./index.css";
 
-export default class Root extends Component {
-  render() {
-    return (
-      <Provider store={store}>
-        <IntlProvider loading={null} locale="fr">
-          <App />
-        </IntlProvider>
-      </Provider>
-    );
-  }
+export default function Root() {
+  return (
+    <Provider store={store}>
+      <IntlProvider loading={null} locale="fr">
+        <App />
+      </IntlProvider>
+    </Provider>
+  );
 }


### PR DESCRIPTION
## Summary
- Rewrite `App`, `Root`, `Format`, `FormatList`, and `CSVInput` from class components to function components, ahead of an upcoming UI update.
- No behavior changes; `componentDidMount` in `App` becomes a `useEffect`, and `CSVInput`'s prop mutation is replaced with a local destructure to satisfy the `react-hooks/immutability` rule.

## Test plan
- [x] `bunx eslint` clean on all changed files (`--max-warnings=0`)
- [x] `bun test` — same 3 pre-existing failures as on `master` (missing `enzyme` package, unrelated to this change)