### PR TITLE
style: sober dark theme foundation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
     <meta name="apple-mobile-web-app-title" content="Movie Manager">
     <meta name="application-name" content="Movie Manager">
     <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#15171c">
     <title>Movie manager</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -13,8 +13,8 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
+    "theme_color": "#15171c",
+    "background_color": "#15171c",
     "start_url": "https://mm.laurentjanet.fr",
     "display": "standalone"
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,39 +1,10 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 80px;
-}
-
-.App-header {
-  background-color: #222;
-  height: 150px;
-  padding: 20px;
-  color: white;
-}
-
-.App-intro {
-  font-size: large;
-}
-
 .main-container {
   z-index: 0;
   position: relative;
 }
 
 .main-container--hidden {
-   width: 100vw;
-   height: 100vh;
-   overflow: hidden;
- }
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
 }

--- a/src/Core/components/FlashMessage/FlashMessage.css
+++ b/src/Core/components/FlashMessage/FlashMessage.css
@@ -6,17 +6,19 @@
   width: 100vw;
   animation: slide-in 0.4s linear forwards, slide-out 0.4s 1s linear forwards;
   text-align: center;
-  color: #000;
+  color: var(--color-text-primary);
 }
 
 .flash-message-container[status="success"] {
-  color: #fff;
+  color: var(--color-bg);
   font-weight: 600;
-  background-color: #aed69b;
+  background-color: var(--color-accent);
 }
 
 .flash-message-container[status="failure"] {
-  background-color: #e3665a;
+  color: var(--color-bg);
+  font-weight: 600;
+  background-color: var(--color-danger);
 }
 
 .flash-message-container p {

--- a/src/Core/components/Loader/Loader.css
+++ b/src/Core/components/Loader/Loader.css
@@ -1,7 +1,7 @@
 .loader-overlay {
   position: fixed;
   top: -100vh;
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: var(--color-overlay);
   width: 100vw;
   height: 100vh;
   z-index: 1;
@@ -23,7 +23,7 @@
   width: 5px;
   height: 5px;
   border-radius: 5px;
-  background-color: #fff;
+  background-color: var(--color-text-primary);
   margin-right: 5px;
   animation: blink 1s infinite;
 }

--- a/src/Format/Item/Format.css
+++ b/src/Format/Item/Format.css
@@ -1,6 +1,8 @@
 .format {
   font-size: 9px;
   text-transform: uppercase;
-  height: 10px;
-  filter: drop-shadow(0 0 1px #fff);
+  height: 14px;
+  padding: 2px 3px;
+  background-color: var(--color-surface-raised);
+  border-radius: var(--radius-sm);
 }

--- a/src/Format/List/FormatList.css
+++ b/src/Format/List/FormatList.css
@@ -1,9 +1,11 @@
 .format-list {
   margin-top: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .format-list .format {
-  margin-right: 4px;
   display: inline-block;
   vertical-align: middle;
 }

--- a/src/Home.css
+++ b/src/Home.css
@@ -24,7 +24,7 @@
   padding: 5px 10px;
   line-height: 30px;
   display: inline-block;
-  color: #000;
+  color: var(--color-text-secondary);
   text-align: right;
   font-size: 12px;
 }
@@ -37,10 +37,11 @@
   height: 40px;
   text-align: center;
   z-index: 2;
-  color: #fff;
+  color: var(--color-bg);
   line-height: 40px;
-  background-color: #59cd90;
+  background-color: var(--color-accent);
   text-decoration: none;
+  font-weight: 600;
 }
 
 .home-container .previous-btn {
@@ -72,7 +73,6 @@
     flex-direction: column;
     padding: 0px 20px 40px 20px;
   }
-
 
   .home-container .add-movie-btn {
     position: fixed;

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -6,11 +6,16 @@
   text-align: left;
   font-size: 11px;
   line-height: 14px;
-  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: 0 0 2px var(--color-shadow);
 }
 
 .movie-item h3 {
   margin: 0;
+  color: var(--color-text-primary);
+  font-size: 1rem;
+  font-weight: 700;
 }
 
 .movie-item picture,
@@ -34,11 +39,16 @@
   padding: 5px 10px;
 }
 
+.movie-item small {
+  color: var(--color-text-secondary);
+}
+
 .movie-item .infos {
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
   flex-direction: column;
+  color: var(--color-text-secondary);
 }
 
 .movie-item .infos > * {
@@ -47,6 +57,7 @@
 
 .movie-item p {
   margin: 0;
+  color: var(--color-text-secondary);
 }
 
 .movie-item .options {
@@ -62,7 +73,7 @@
   text-align: center;
   vertical-align: center;
   line-height: 40px;
-  color: #fff;
+  color: var(--color-text-primary);
 }
 
 .movie-item .options button {
@@ -70,12 +81,12 @@
 }
 
 .movie-item .options button:first-child {
-  background-color: #3fa7d6;
+  background-color: var(--color-info);
   flex-basis: 80%;
 }
 
 .movie-item .options button:last-child {
-  background-color: #ee6352;
+  background-color: var(--color-danger);
   flex-basis: 20%;
 }
 
@@ -107,13 +118,13 @@
 
   .movie-item__content,
   .options {
-    background-color: rgba(0, 0, 0, 0.4);
+    background-color: var(--color-overlay);
   }
 
   .movie-item__content {
     grid-column: 1;
     grid-row: 2;
-    color: #fff;
+    color: var(--color-text-primary);
     padding-bottom: 5px;
   }
 

--- a/src/Movie/components/ProposalList.css
+++ b/src/Movie/components/ProposalList.css
@@ -5,8 +5,9 @@
   left: 4px;
   width: calc(100vw - 8px);
   height: calc(100vh - 8px);
-  background: white;
-  box-shadow: 0 0 16px rgb(0, 0, 0);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: 0 0 16px var(--color-shadow);
   padding: 4px;
   overflow: auto;
 }

--- a/src/Search/components/SearchBox.css
+++ b/src/Search/components/SearchBox.css
@@ -1,12 +1,15 @@
 .searchbox input {
-    display: block;
-    width: 100%;
-    height: 40px;
-    border: 1px solid rgba(0,0,0,.4);
-    -webkit-appearance: textfield;
+  display: block;
+  width: 100%;
+  height: 40px;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface-raised);
+  color: var(--color-text-primary);
+  -webkit-appearance: textfield;
 }
 
 .searchbox span {
-    font-weight: bold;
-    padding: 2px 4px;
+  font-weight: bold;
+  padding: 2px 4px;
+  color: var(--color-text-primary);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,30 @@
 @import url("https://fonts.googleapis.com/css?family=Open+Sans");
 
+:root {
+  color-scheme: dark;
+
+  --color-bg: #15171c;
+  --color-surface: #1d2026;
+  --color-surface-raised: #262a32;
+  --color-border: #343945;
+
+  --color-text-primary: #f2f3f5;
+  --color-text-secondary: #a9adba;
+  --color-text-muted: #6f7480;
+
+  --color-accent: #59cd90;
+  --color-accent-strong: #7fe0a8;
+  --color-info: #3fa7d6;
+  --color-danger: #ee6352;
+  --color-danger-strong: #ff8577;
+
+  --color-overlay: rgb(0 0 0 / 60%);
+  --color-shadow: rgb(0 0 0 / 45%);
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -8,5 +33,6 @@ body {
   margin: 0;
   padding: 0;
   font-family: "Open Sans", sans-serif;
-  color: #3f3f54;
+  background-color: var(--color-bg);
+  color: var(--color-text-secondary);
 }


### PR DESCRIPTION
## Summary
- Introduce a shared color/radius token set (CSS custom properties) in `index.css`, including `color-scheme: dark` so native form controls follow suit.
- Apply the theme to global chrome (body, loader, flash message, search box, proposal list) and to the movie card: titles get strong contrast, secondary details (synopsis, dates, direction) stay legible but subdued, and format badges get a chip background for clear visibility.
- Update PWA `theme-color`/manifest colors to match.
- Drop unused CRA boilerplate classes from `App.css`.

This is the global appearance pass. Page-by-page styling refinements will follow in their own branches/PRs.

## Test plan
- [x] Verified against a live local instance (API + client, 850 movies) — desktop and mobile viewports
- [x] `bunx eslint` — no new issues introduced (pre-existing errors are in untouched files)