### PR TITLE
style(auth): detached card + floating labels for login/sign-in

### DIFF
--- a/src/Auth/components/FinishForm.js
+++ b/src/Auth/components/FinishForm.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 
 import { LOGIN_PAGE } from "Auth/constants";
 import { finishSignIn } from "Auth/graphql/client";
+
+import "./Form.css";
 
 const INITIAL = "initial";
 const SUCCESS = "success";
@@ -10,14 +12,10 @@ const FAILURE = "failure";
 
 export const FinishForm = () => {
   const location = useLocation();
-  const [token, setToken] = useState("");
+  const [token, setToken] = useState(() =>
+    location.search ? location.search.replace("?token=", "") : ""
+  );
   const [status, setStatus] = useState(INITIAL);
-
-  useEffect(() => {
-    if (location.search) {
-      setToken(location.search.replace("?token=", ""));
-    }
-  }, [location, setToken]);
 
   return (
     <div className="authForm">
@@ -38,8 +36,10 @@ export const FinishForm = () => {
           <div className="formField">
             <label htmlFor="token">Account validation token</label>
             <input
+              id="token"
               name="token"
               type="text"
+              placeholder=" "
               onChange={({ currentTarget: { value } }) => setToken(value)}
               value={token}
               required

--- a/src/Auth/components/Form.css
+++ b/src/Auth/components/Form.css
@@ -9,39 +9,88 @@
 .authForm form {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: stretch;
+  width: min(340px, calc(100vw - 48px));
+  padding: 32px 28px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 12px 32px var(--color-shadow);
 }
 
-.authForm input {
-  width: 200px;
-  margin-left: 5px;
-  line-height: 25px;
-  margin-bottom: 15px;
+.authForm .formField {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+.authForm .formField input {
+  width: 100%;
+  height: 52px;
+  padding: 22px 12px 8px;
+  background-color: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+  font-size: 15px;
+}
+
+.authForm .formField input:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.authForm .formField label {
+  position: absolute;
+  left: 13px;
+  top: 16px;
+  font-size: 15px;
+  line-height: 1;
+  color: var(--color-text-secondary);
+  pointer-events: none;
+  transition: top 0.15s ease, font-size 0.15s ease, color 0.15s ease;
+}
+
+.authForm .formField:has(input:focus) label,
+.authForm .formField:has(input:not(:placeholder-shown)) label {
+  top: 6px;
+  font-size: 11px;
+  color: var(--color-accent);
 }
 
 .authForm .formActions {
-  margin-top: 15px;
-  align-self: center;
+  margin-top: 4px;
+  align-self: stretch;
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
 }
 
 .authForm .formActions button {
   cursor: pointer;
+  width: 100%;
   height: 44px;
-  border-radius: 20%;
+  border-radius: var(--radius-sm);
   border: 0;
   padding: 5px 10px;
+  background-color: var(--color-accent);
+  color: var(--color-bg);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.authForm .formActions button:disabled {
+  background-color: var(--color-surface-raised);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
 }
 
 .authForm form a {
   align-self: center;
+  margin-top: 16px;
+  color: var(--color-info);
+  font-size: 13px;
+  text-decoration: none;
 }
 
-.login-options-container {
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.authForm form a:hover {
+  text-decoration: underline;
 }

--- a/src/Auth/components/LogInForm.js
+++ b/src/Auth/components/LogInForm.js
@@ -33,8 +33,10 @@ export const LogInForm = () => {
         <div className="formField">
           <label htmlFor="email">E-mail address</label>
           <input
+            id="email"
             name="email"
             type="email"
+            placeholder=" "
             required
             value={email}
             onChange={({ currentTarget: { value } }) => setEmail(value)}
@@ -43,8 +45,10 @@ export const LogInForm = () => {
         <div className="formField">
           <label htmlFor="password">Password</label>
           <input
+            id="password"
             name="password"
             type="password"
+            placeholder=" "
             required
             value={password}
             onChange={({ currentTarget: { value } }) => setPassword(value)}

--- a/src/Auth/components/StartForm.js
+++ b/src/Auth/components/StartForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
 import { startSignIn } from "Auth/graphql/client";
@@ -15,18 +15,9 @@ export const StartForm = () => {
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
   const [processStatus, setProcessStatus] = useState(INITIAL);
-  const [passwordMatch, setPasswordMatch] = useState(false);
-  const [isFormValid, setFormValidity] = useState(false);
 
-  useEffect(() => {
-    setFormValidity(!!(email && passwordMatch));
-  }, [email, passwordMatch, setFormValidity]);
-
-  useEffect(() => {
-    if (password && passwordConfirmation) {
-      setPasswordMatch(password === passwordConfirmation);
-    }
-  }, [password, passwordConfirmation]);
+  const passwordMatch = !!password && password === passwordConfirmation;
+  const isFormValid = !!email && passwordMatch;
 
   return (
     <div className="authForm">
@@ -48,8 +39,10 @@ export const StartForm = () => {
           <div className="formField">
             <label htmlFor="email">E-mail address</label>
             <input
+              id="email"
               name="email"
               type="email"
+              placeholder=" "
               onChange={({ currentTarget: { value } }) => setEmail(value)}
               required
             />
@@ -57,8 +50,10 @@ export const StartForm = () => {
           <div className="formField">
             <label htmlFor="password">Password</label>
             <input
+              id="password"
               name="password"
               type="password"
+              placeholder=" "
               onChange={({ currentTarget: { value } }) => setPassword(value)}
               required
             />
@@ -66,8 +61,10 @@ export const StartForm = () => {
           <div className="formField">
             <label htmlFor="passwordConfirm">Password confirm</label>
             <input
+              id="passwordConfirm"
               name="passwordConfirm"
               type="password"
+              placeholder=" "
               onChange={({ currentTarget: { value } }) =>
                 setPasswordConfirmation(value)
               }


### PR DESCRIPTION
## Summary
- The log-in, sign-in-start, and sign-in-finish forms now sit in a raised card (surface color, border, shadow) instead of lying flat on the page background.
- Labels float into the input fields (CSS `:has()` + `:placeholder-shown`, no JS), following the common modern pattern for this kind of form.
- Fixes found while touching these files: `label htmlFor` never matched an `id` (accessibility), `FinishForm` was missing its `Form.css` import (broken layout on direct navigation to that route), and `StartForm`/`FinishForm` computed state synchronously inside effects instead of deriving it directly — now flagged by the current `eslint-plugin-react-hooks`.

Branched off `theme/global-dark-theme` since this relies on its CSS custom properties (not yet merged) — base this PR on that branch, or retarget to `master` once #39 lands.

## Test plan
- [x] Verified on the live local instance (log-in, sign-in start, sign-in finish) — desktop and mobile
- [x] Checked floating-label focus/filled states and the sign-in form's live validation
- [x] `bunx eslint --max-warnings=0` clean on all changed files
- [x] `bun test` — same pre-existing failures as before (missing `enzyme`), unrelated to this change