### PR TITLE
style(home): unified movie grid with dialog detail view

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,12 @@
       "globals": {
         "Bun": "readonly"
       }
+    },
+    {
+      "files": ["**/*.spec.js", "test/**"],
+      "env": {
+        "jest": true
+      }
     }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,9 @@
       "name": "pwa",
       "dependencies": {
         "@apollo/client": "^3.14.1",
-        "@testing-library/jest-dom": "^5.11.4",
-        "@testing-library/react": "^11.1.0",
-        "@testing-library/user-event": "^12.1.10",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.4",
         "apollo-upload-client": "^17.0.0",
         "graphql": "^16.14.2",
         "jwt-decode": "^4.0.0",
@@ -23,6 +23,8 @@
         "redux-thunk": "^3.1.0",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "^20.11.2",
+        "@testing-library/dom": "^10.4.1",
         "eslint": "^8.6.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-react": "^7.37.5",
@@ -66,8 +68,6 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@babel/runtime-corejs3": ["@babel/runtime-corejs3@7.29.7", "", { "dependencies": { "core-js-pure": "^3.48.0" } }, "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ=="],
-
     "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
@@ -92,23 +92,13 @@
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.2", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.2" } }, "sha512-7fkpoXZWzyxaBkzRtlD0wRU5ckxbNT4j6BywzpSYh+SFPsGxEVmNR9KHaMwM2xkHB0pADQLl4Z8DSrztECJ7Ww=="],
+
     "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
 
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
-
-    "@jest/diff-sequences": ["@jest/diff-sequences@30.4.0", "", {}, "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g=="],
-
-    "@jest/expect-utils": ["@jest/expect-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0" } }, "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ=="],
-
-    "@jest/get-type": ["@jest/get-type@30.1.0", "", {}, "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA=="],
-
-    "@jest/pattern": ["@jest/pattern@30.4.0", "", { "dependencies": { "@types/node": "*", "jest-regex-util": "30.4.0" } }, "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg=="],
-
-    "@jest/schemas": ["@jest/schemas@30.4.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q=="],
-
-    "@jest/types": ["@jest/types@26.6.2", "", { "dependencies": { "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^15.0.0", "chalk": "^4.0.0" } }, "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -126,25 +116,15 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
-    "@testing-library/dom": ["@testing-library/dom@7.31.2", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^4.2.0", "aria-query": "^4.2.2", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.6", "lz-string": "^1.4.4", "pretty-format": "^26.6.2" } }, "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ=="],
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@7.0.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" }, "peerDependencies": { "@testing-library/dom": ">=10 <11", "vitest": ">= 0.32" }, "optionalPeers": ["vitest"] }, "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw=="],
 
-    "@testing-library/jest-dom": ["@testing-library/jest-dom@5.17.0", "", { "dependencies": { "@adobe/css-tools": "^4.0.1", "@babel/runtime": "^7.9.2", "@types/testing-library__jest-dom": "^5.9.1", "aria-query": "^5.0.0", "chalk": "^3.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.5.6", "lodash": "^4.17.15", "redent": "^3.0.0" } }, "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg=="],
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
-    "@testing-library/react": ["@testing-library/react@11.2.7", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@testing-library/dom": "^7.28.1" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA=="],
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.4", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew=="],
 
-    "@testing-library/user-event": ["@testing-library/user-event@12.8.3", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ=="],
-
-    "@types/aria-query": ["@types/aria-query@4.2.2", "", {}, "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="],
-
-    "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
-
-    "@types/istanbul-lib-report": ["@types/istanbul-lib-report@3.0.3", "", { "dependencies": { "@types/istanbul-lib-coverage": "*" } }, "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA=="],
-
-    "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
-
-    "@types/jest": ["@types/jest@30.0.0", "", { "dependencies": { "expect": "^30.0.0", "pretty-format": "^30.0.0" } }, "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA=="],
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
@@ -152,15 +132,11 @@
 
     "@types/react": ["@types/react@18.3.31", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw=="],
 
-    "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
-
-    "@types/testing-library__jest-dom": ["@types/testing-library__jest-dom@5.14.9", "", { "dependencies": { "@types/jest": "*" } }, "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw=="],
-
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
-    "@types/yargs": ["@types/yargs@15.0.20", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg=="],
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
-    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
@@ -184,13 +160,13 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "apollo-upload-client": ["apollo-upload-client@17.0.0", "", { "dependencies": { "extract-files": "^11.0.0" }, "peerDependencies": { "@apollo/client": "^3.0.0", "graphql": "14 - 16" } }, "sha512-pue33bWVbdlXAGFPkgz53TTmxVMrKeQr0mdRcftNY+PoHIdbGZD0hoaXHvO6OePJAkFz7OiCFUf98p1G/9+Ykw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
@@ -222,6 +198,8 @@
 
     "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -233,8 +211,6 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
@@ -256,8 +232,6 @@
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
-    "core-js-pure": ["core-js-pure@3.50.0", "", {}, "sha512-6GP3Pxz4IKyWjAfa747vIu/jilB5z29JWROLqH/b+pXVcpgh6tM06ZIBwSuglgVqzDYURhOK6oEzTrG0bCHitA=="],
-
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
@@ -278,6 +252,8 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -289,6 +265,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.407", "", {}, "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
 
@@ -335,8 +313,6 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
-
-    "expect": ["expect@30.4.1", "", { "dependencies": { "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA=="],
 
     "extract-files": ["extract-files@11.0.0", "", {}, "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ=="],
 
@@ -390,13 +366,13 @@
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
-
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
 
     "graphql-tag": ["graphql-tag@2.12.7", "", { "dependencies": { "tslib": "^2.1.0" }, "peerDependencies": { "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q=="],
+
+    "happy-dom": ["happy-dom@20.11.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -502,18 +478,6 @@
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
-    "jest-diff": ["jest-diff@30.4.1", "", { "dependencies": { "@jest/diff-sequences": "30.4.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.4.1" } }, "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA=="],
-
-    "jest-matcher-utils": ["jest-matcher-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.4.1", "pretty-format": "30.4.1" } }, "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A=="],
-
-    "jest-message-util": ["jest-message-util@30.4.1", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.4.1", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "jest-util": "30.4.1", "picomatch": "^4.0.3", "pretty-format": "30.4.1", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ=="],
-
-    "jest-mock": ["jest-mock@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "jest-util": "30.4.1" } }, "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw=="],
-
-    "jest-regex-util": ["jest-regex-util@30.4.0", "", {}, "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg=="],
-
-    "jest-util": ["jest-util@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw=="],
-
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
@@ -543,8 +507,6 @@
     "listr2": ["listr2@4.0.5", "", { "dependencies": { "cli-truncate": "^2.1.0", "colorette": "^2.0.16", "log-update": "^4.0.0", "p-map": "^4.0.0", "rfdc": "^1.3.0", "rxjs": "^7.5.5", "through": "^2.3.8", "wrap-ansi": "^7.0.0" }, "peerDependencies": { "enquirer": ">= 2.3.0 < 3" }, "optionalPeers": ["enquirer"] }, "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -634,7 +596,7 @@
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
-    "pretty-format": ["pretty-format@26.6.2", "", { "dependencies": { "@jest/types": "^26.6.2", "ansi-regex": "^5.0.0", "ansi-styles": "^4.0.0", "react-is": "^17.0.1" } }, "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg=="],
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
@@ -648,11 +610,7 @@
 
     "react-intl": ["react-intl@10.1.20", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "3.5.16", "@formatjs/intl": "4.1.18", "intl-messageformat": "11.2.13" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0" } }, "sha512-dvD9F7CqjlB/cIWakFzScGVPDmhWk34cFWY0etWuVNc07Zmc56OKjQwqu9q74evbttSto5wFXchZtvdRXy/Tkg=="],
 
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "react-is-18": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "react-is-19": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
 
@@ -720,11 +678,7 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
-
     "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
-
-    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -788,6 +742,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -804,6 +760,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
@@ -818,33 +776,19 @@
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
-    "@testing-library/dom/aria-query": ["aria-query@4.2.2", "", { "dependencies": { "@babel/runtime": "^7.10.2", "@babel/runtime-corejs3": "^7.10.2" } }, "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA=="],
+    "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
-    "@testing-library/jest-dom/chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
-
-    "@types/jest/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "eslint-plugin-react/doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "jest-diff/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
-
-    "jest-matcher-utils/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
-
-    "jest-message-util/@jest/types": ["@jest/types@30.4.1", "", { "dependencies": { "@jest/pattern": "30.4.0", "@jest/schemas": "30.4.1", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ=="],
-
-    "jest-message-util/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
-
-    "jest-message-util/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
-
-    "jest-mock/@jest/types": ["@jest/types@30.4.1", "", { "dependencies": { "@jest/pattern": "30.4.0", "@jest/schemas": "30.4.1", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ=="],
-
-    "jest-util/@jest/types": ["@jest/types@30.4.1", "", { "dependencies": { "@jest/pattern": "30.4.0", "@jest/schemas": "30.4.1", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ=="],
-
-    "jest-util/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+    "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "listr2/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
 
@@ -852,37 +796,25 @@
 
     "log-update/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
-
     "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@testing-library/jest-dom/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "@types/jest/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "jest-diff/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "jest-matcher-utils/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "jest-message-util/@jest/types/@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
-
-    "jest-message-util/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "jest-mock/@jest/types/@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
-
-    "jest-util/@jest/types/@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
     "listr2/cli-truncate/slice-ansi": ["slice-ansi@3.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ=="],
 
     "listr2/cli-truncate/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "log-update/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "log-update/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -891,6 +823,8 @@
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "listr2/cli-truncate/slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "listr2/cli-truncate/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,5 @@
 [serve.static]
 env = "REACT_APP_*"
+
+[test]
+preload = ["./test/setup.js", "./test/setup-matchers.js"]

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.14.1",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.4",
     "apollo-upload-client": "^17.0.0",
     "graphql": "^16.14.2",
     "jwt-decode": "^4.0.0",
@@ -27,6 +27,8 @@
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.11.2",
+    "@testing-library/dom": "^10.4.1",
     "eslint": "^8.6.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "^7.37.5",

--- a/src/Duration/Duration.spec.js
+++ b/src/Duration/Duration.spec.js
@@ -1,13 +1,10 @@
 import React from "react";
-import { shallow, configure } from "enzyme";
-
-import Adapter from "enzyme-adapter-react-16";
-configure({ adapter: new Adapter() });
+import { render, screen } from "@testing-library/react";
 
 import Duration from "./Duration";
 
-test("Duration properly render the value passed in props", () => {
-  const component = shallow(<Duration value="125" />);
+test("Duration properly renders the value passed in props", () => {
+  render(<Duration value="125" />);
 
-  expect(component.text()).toEqual("125m (2h05)");
+  expect(screen.getByText("125m (2h05)")).toBeInTheDocument();
 });

--- a/src/Format/Item/Format.css
+++ b/src/Format/Item/Format.css
@@ -3,6 +3,6 @@
   text-transform: uppercase;
   height: 14px;
   padding: 2px 3px;
-  background-color: var(--color-surface-raised);
+  background-color: var(--color-badge-bg);
   border-radius: var(--radius-sm);
 }

--- a/src/Format/Item/Format.css
+++ b/src/Format/Item/Format.css
@@ -6,3 +6,11 @@
   background-color: var(--color-badge-bg);
   border-radius: var(--radius-sm);
 }
+
+/* This particular logo's own colors already read fine on a dark
+   surface, so it only needs a thin outline for definition instead of
+   the white backing plate the others rely on for contrast. */
+.format[src$="/4K.svg"] {
+  background-color: transparent;
+  border: 1px solid var(--color-text-primary);
+}

--- a/src/Format/Item/Format.spec.js
+++ b/src/Format/Item/Format.spec.js
@@ -1,13 +1,12 @@
 import React from "react";
-import { shallow, configure } from "enzyme";
-
-import Adapter from "enzyme-adapter-react-16";
-configure({ adapter: new Adapter() });
+import { render, screen } from "@testing-library/react";
 
 import Format from "./Format";
 
-test("Format properly render the label props", () => {
-  const component = shallow(<Format label="labelTest" />);
+test("Format renders the format's logo with an accessible name", () => {
+  render(<Format name="DVD" logo="dvd.svg" />);
 
-  expect(component.text()).toEqual("labelTest");
+  const logo = screen.getByAltText("DVD");
+  expect(logo).toBeInTheDocument();
+  expect(logo).toHaveAttribute("src", expect.stringContaining("dvd.svg"));
 });

--- a/src/Format/List/FormatList.js
+++ b/src/Format/List/FormatList.js
@@ -8,9 +8,7 @@ function FormatList({ formats }) {
   return (
     <div className="format-list">
       {formats.map((format) => {
-        return (
-          <Format key={format.id} label={format.name} logo={format.logo} />
-        );
+        return <Format key={format.id} name={format.name} logo={format.logo} />;
       })}
     </div>
   );

--- a/src/Format/List/FormatList.spec.js
+++ b/src/Format/List/FormatList.spec.js
@@ -1,14 +1,19 @@
 import React from "react";
-import { shallow, configure } from "enzyme";
-
-import Adapter from "enzyme-adapter-react-16";
-configure({ adapter: new Adapter() });
+import { render, screen } from "@testing-library/react";
 
 import FormatList from "./FormatList";
 
-test("FormatList properly render 3 Format components", () => {
-  const formats = ["blu-ray", "dvd", "4k"];
-  const component = shallow(<FormatList formats={formats} />);
+test("FormatList renders one logo per format", () => {
+  const formats = [
+    { id: 1, name: "Blu-ray", logo: "bluray.svg" },
+    { id: 2, name: "DVD", logo: "dvd.svg" },
+    { id: 3, name: "4K", logo: "4k.svg" },
+  ];
 
-  expect(component.find("Format").length).toEqual(3);
+  render(<FormatList formats={formats} />);
+
+  expect(screen.getAllByRole("img")).toHaveLength(3);
+  expect(screen.getByAltText("Blu-ray")).toBeInTheDocument();
+  expect(screen.getByAltText("DVD")).toBeInTheDocument();
+  expect(screen.getByAltText("4K")).toBeInTheDocument();
 });

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -219,10 +219,3 @@
   animation-duration: 0.28s;
   animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }
-
-/* dialog.showModal() runs inside the transition callback, so the
-   dialog is promoted to the top layer after the transition's own
-   pseudo-element tree, which would otherwise stack it underneath. */
-::view-transition {
-  z-index: 2147483647;
-}

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -196,7 +196,7 @@
     margin: auto;
     width: min(720px, calc(100vw - 64px));
     height: auto;
-    max-height: 85vh;
+    max-height: 415px;
     border-radius: var(--radius-md);
     box-shadow: 0 20px 60px var(--color-shadow);
   }
@@ -218,4 +218,12 @@
 ::view-transition-old(*),
 ::view-transition-new(*) {
   animation-duration: 0.32s;
+}
+
+/* Only the poster morphs; everything else swaps instantly instead of
+   cross-fading, so the two animations don't compete visually. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
 }

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -207,3 +207,15 @@
     max-height: none;
   }
 }
+
+/* View transition (poster morph from grid to dialog): the whole
+   dialog still cross-fades in with the default root transition, so
+   it appears together with the poster instead of the poster catching
+   up afterwards. Only the pacing is tuned. */
+
+::view-transition-group(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-duration: 0.28s;
+  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -3,7 +3,7 @@
   position: relative;
   display: block;
   width: 100%;
-  aspect-ratio: 2 / 3;
+  aspect-ratio: 27 / 40;
   padding: 0;
   border: 0;
   border-radius: var(--radius-md);
@@ -94,7 +94,7 @@
 .movie-dialog__poster {
   position: relative;
   flex: 0 0 auto;
-  aspect-ratio: 2 / 3;
+  aspect-ratio: 27 / 40;
   max-height: 45vh;
   overflow: hidden;
 }
@@ -203,6 +203,19 @@
 
   .movie-dialog__poster {
     flex: 0 0 280px;
+    align-self: flex-start;
     max-height: none;
   }
+}
+
+/* View transition (poster morph from grid to dialog) */
+
+::view-transition-group(*) {
+  animation-duration: 0.32s;
+  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-duration: 0.32s;
 }

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -1,171 +1,208 @@
 .movie-item {
-  display: grid;
-  grid-template-areas: "picture content" "options options";
-  grid-template-columns: 50px calc(100% - 50px);
-  justify-content: left;
-  text-align: left;
-  font-size: 11px;
-  line-height: 14px;
-  background-color: var(--color-surface);
+  container-type: inline-size;
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  padding: 0;
+  border: 0;
   border-radius: var(--radius-md);
+  overflow: hidden;
+  background-color: var(--color-surface);
   box-shadow: 0 0 2px var(--color-shadow);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
-.movie-item h3 {
-  margin: 0;
+.movie-item:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.movie-item__poster,
+.movie-item__poster picture,
+.movie-item__poster img,
+.movie-item__poster .picture-shadow-container {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.movie-item__poster img {
+  object-fit: cover;
+}
+
+.movie-item__caption {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  padding: 20px 8px 8px;
+  background: linear-gradient(to top, rgb(0 0 0 / 85%), transparent);
+}
+
+.movie-item__title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
   color: var(--color-text-primary);
-  font-size: 1rem;
+  font-size: 0.8rem;
   font-weight: 700;
+  line-height: 1.25;
 }
 
-.movie-item picture,
-.movie-item .picture-shadow-container {
-  grid-area: picture;
-  justify-self: center;
-  width: 50px;
+@container (min-width: 220px) {
+  .movie-item__title {
+    font-size: 1rem;
+  }
+}
+
+.movie-item .format-list {
+  margin-top: 4px;
+}
+
+/* Dialog */
+
+.movie-dialog {
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  background-color: var(--color-surface);
+}
+
+.movie-dialog::backdrop {
+  background-color: var(--color-overlay);
+}
+
+.movie-dialog[open] {
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
+  position: fixed;
+  inset: 0;
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
+  border-radius: 0;
+}
+
+.movie-dialog__poster {
+  position: relative;
+  flex: 0 0 auto;
+  aspect-ratio: 2 / 3;
+  max-height: 45vh;
   overflow: hidden;
 }
 
-.movie-item picture img {
-  max-width: 100%;
-}
-
-.movie-item__content {
-  grid-area: content;
-  box-sizing: border-box;
-  padding: 5px 10px;
-}
-
-.movie-item small {
-  color: var(--color-text-secondary);
-}
-
-.movie-item .infos {
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
-  flex-direction: column;
-  color: var(--color-text-secondary);
-}
-
-.movie-item .infos > * {
-  margin-right: 5px;
-}
-
-.movie-item p {
-  margin: 0;
-  color: var(--color-text-secondary);
-}
-
-.movie-item .options {
-  grid-area: options;
+.movie-dialog__poster picture,
+.movie-dialog__poster img,
+.movie-dialog__poster .picture-shadow-container {
+  display: block;
   width: 100%;
-  text-align: right;
-  height: 40px;
-  display: flex;
-  align-self: flex-end;
+  height: 100%;
+  object-fit: cover;
 }
 
-.movie-item .options > * {
-  text-align: center;
-  vertical-align: center;
-  line-height: 40px;
+.movie-dialog__content {
+  container-type: inline-size;
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.movie-dialog__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 50%;
+  background-color: var(--color-overlay);
   color: var(--color-text-primary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
 }
 
-.movie-item .options button {
-  border: none;
+.movie-dialog__content h2 {
+  margin: 0 32px 4px 0;
+  font-size: 1.25rem;
 }
 
-.movie-item .options button:first-child {
-  background-color: var(--color-info);
-  flex-basis: 80%;
+.movie-dialog__content small {
+  display: block;
+  color: var(--color-text-secondary);
 }
 
-.movie-item .options button:last-child {
-  background-color: var(--color-danger);
-  flex-basis: 20%;
+.movie-dialog__content .infos {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 12px 0;
+  color: var(--color-text-secondary);
 }
 
-@media all and (min-width: 501px) {
-  .movie-item {
-    display: grid;
-    grid-template-areas: "picture" "content" "options";
-    grid-template-columns: 1fr;
-    width: 150px;
-    height: 200px;
-    margin: 0 auto 15px auto;
-  }
-
-  .movie-item > *:not(picture) {
-    z-index: 10;
-  }
-
-  .movie-item picture,
-  .movie-item .picture-shadow-container,
-  .movie-item__content {
-    width: 100%;
-  }
-
-  .movie-item picture,
-  .movie-item .picture-shadow-container {
-    z-index: 0;
-    grid-row: 1 / span 3;
-  }
-
-  .movie-item__content,
-  .options {
-    background-color: var(--color-overlay);
-  }
-
-  .movie-item__content {
-    grid-column: 1;
-    grid-row: 2;
-    color: var(--color-text-primary);
-    padding-bottom: 5px;
-  }
-
-  .movie-item .options {
+@container (min-width: 360px) {
+  .movie-dialog__content .infos {
     flex-direction: row;
-    justify-content: flex-end;
-    align-items: flex-end;
-  }
-
-  .movie-item section {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .movie-item .infos {
-    align-items: flex-start;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
   }
 }
 
-@media all and (min-width: 980px) {
-  .movie-item {
-    display: grid;
-    grid-template-areas: "picture content" "picture options";
-    grid-template-columns: 150px 1fr;
-    height: 200px;
-    width: auto;
-    margin: 0;
+.movie-dialog__synopsis {
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.movie-dialog__actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.movie-dialog__actions button {
+  flex: 1;
+  height: 44px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.movie-dialog__actions button:first-child {
+  background-color: var(--color-info);
+}
+
+.movie-dialog__actions button:last-child {
+  background-color: var(--color-danger);
+}
+
+@media all and (min-width: 768px) {
+  .movie-dialog[open] {
+    flex-direction: row;
+    margin: auto;
+    width: min(720px, calc(100vw - 64px));
+    height: auto;
+    max-height: 85vh;
+    border-radius: var(--radius-md);
+    box-shadow: 0 20px 60px var(--color-shadow);
   }
 
-  .movie-item picture,
-  .movie-item .picture-shadow-container {
-    grid-area: picture;
-    justify-self: center;
-    grid-row: 1 / span 2;
-  }
-
-  .movie-item__content {
-    grid-area: content;
-    background-color: transparent;
-    color: inherit;
-    height: calc(100% - 40px);
+  .movie-dialog__poster {
+    flex: 0 0 280px;
+    max-height: none;
   }
 }

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -207,23 +207,3 @@
     max-height: none;
   }
 }
-
-/* View transition (poster morph from grid to dialog) */
-
-::view-transition-group(*) {
-  animation-duration: 0.32s;
-  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
-}
-
-::view-transition-old(*),
-::view-transition-new(*) {
-  animation-duration: 0.32s;
-}
-
-/* Only the poster morphs; everything else swaps instantly instead of
-   cross-fading, so the two animations don't compete visually. */
-::view-transition-old(root),
-::view-transition-new(root) {
-  animation: none;
-  mix-blend-mode: normal;
-}

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -219,3 +219,10 @@
   animation-duration: 0.28s;
   animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }
+
+/* dialog.showModal() runs inside the transition callback, so the
+   dialog is promoted to the top layer after the transition's own
+   pseudo-element tree, which would otherwise stack it underneath. */
+::view-transition {
+  z-index: 2147483647;
+}

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -38,8 +38,13 @@
   position: absolute;
   inset-inline: 0;
   bottom: 0;
-  padding: 20px 8px 8px;
-  background: linear-gradient(to top, rgb(0 0 0 / 85%), transparent);
+  padding: 28px 8px 8px;
+  background: linear-gradient(
+    to top,
+    rgb(0 0 0 / 90%) 0%,
+    rgb(0 0 0 / 90%) 45%,
+    transparent 100%
+  );
 }
 
 .movie-item__title {
@@ -94,14 +99,42 @@
 .movie-dialog__poster {
   position: relative;
   flex: 0 0 auto;
-  aspect-ratio: 27 / 40;
-  max-height: 45vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: min(415px, 45vh);
   overflow: hidden;
 }
 
-.movie-dialog__poster picture,
-.movie-dialog__poster img,
-.movie-dialog__poster .picture-shadow-container {
+.movie-dialog__poster-backdrop {
+  position: absolute;
+  inset: 0;
+}
+
+.movie-dialog__poster-backdrop picture,
+.movie-dialog__poster-backdrop img,
+.movie-dialog__poster-backdrop .picture-shadow-container {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.15);
+  filter: blur(24px) brightness(0.55);
+}
+
+.movie-dialog__poster-frame {
+  position: relative;
+  flex: 0 0 auto;
+  width: 280px;
+  max-width: 100%;
+  aspect-ratio: 27 / 40;
+  overflow: hidden;
+  box-shadow: 0 8px 24px var(--color-shadow);
+}
+
+.movie-dialog__poster-frame picture,
+.movie-dialog__poster-frame img,
+.movie-dialog__poster-frame .picture-shadow-container {
   display: block;
   width: 100%;
   height: 100%;
@@ -204,7 +237,7 @@
   .movie-dialog__poster {
     flex: 0 0 280px;
     align-self: flex-start;
-    max-height: none;
+    height: auto;
   }
 }
 

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -86,6 +86,7 @@ export const Movie = ({
           className="movie-item__poster"
           style={{
             viewTransitionName: isOpen ? undefined : posterTransitionName,
+            visibility: isOpen ? "hidden" : "visible",
           }}
         >
           <Image src={posterSrc} alt="" isVisible={showImage} />

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -1,82 +1,21 @@
-import React, { useId, useRef, useState } from "react";
-import { flushSync } from "react-dom";
-import { FormattedDate } from "react-intl";
-import { useNavigate } from "react-router-dom";
-import { useDispatch } from "react-redux";
+import React from "react";
 
 import "./Movie.css";
 
 import { FormatList } from "Format";
-import { Duration } from "Duration";
 import { Image } from "Core";
-import { remove } from "Movie/Actions";
 
 const assetsUrl = process.env.REACT_APP_API_URL;
+export const ACTIVE_POSTER_TRANSITION_NAME = "movie-poster-active";
 
 export const Movie = ({
-  movie: {
-    id,
-    title,
-    poster,
-    originalTitle,
-    direction,
-    duration,
-    releaseDate,
-    formats,
-    synopsis,
-  },
+  movie: { id, title, poster, formats },
   showImage = false,
+  isActive = false,
+  isDialogOpen = false,
+  onSelect,
 }) => {
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-
-  const movieEltRef = useRef();
-  const dialogRef = useRef();
-  const [isOpen, setIsOpen] = useState(false);
-  const titleId = useId();
-
   const posterSrc = `${assetsUrl}/uploads/${poster}`;
-  const posterTransitionName = `movie-poster-${id}`;
-
-  const setDialogOpen = async (open) => {
-    if (open) {
-      // Make sure the dialog's poster is already decoded before the
-      // transition captures it, otherwise it briefly snapshots empty.
-      const preload = new window.Image();
-      preload.src = posterSrc;
-      await (preload.decode ? preload.decode().catch(() => {}) : null);
-
-      // showModal() promotes the dialog to the browser's top layer.
-      // Do this *before* starting the transition so the transition's
-      // own pseudo-element tree - inserted into the top layer right
-      // after - stacks above it instead of underneath. Give the
-      // browser a full frame to settle that promotion first, so it
-      // isn't racing the transition's own setup within the same task.
-      dialogRef.current.showModal();
-      const applyOpenState = () => flushSync(() => setIsOpen(true));
-
-      if (document.startViewTransition) {
-        await new Promise((resolve) =>
-          requestAnimationFrame(() => requestAnimationFrame(resolve))
-        );
-        document.startViewTransition(applyOpenState);
-      } else {
-        applyOpenState();
-      }
-      return;
-    }
-
-    const applyClosedState = () => {
-      flushSync(() => setIsOpen(false));
-      dialogRef.current.close();
-    };
-
-    if (document.startViewTransition) {
-      document.startViewTransition(applyClosedState);
-    } else {
-      applyClosedState();
-    }
-  };
 
   return (
     <li className="movie-list__item">
@@ -84,14 +23,16 @@ export const Movie = ({
         type="button"
         className="movie-item"
         data-item-id={id}
-        ref={movieEltRef}
-        onClick={() => setDialogOpen(true)}
+        onClick={onSelect}
       >
         <span
           className="movie-item__poster"
           style={{
-            viewTransitionName: isOpen ? undefined : posterTransitionName,
-            visibility: isOpen ? "hidden" : "visible",
+            viewTransitionName:
+              isActive && !isDialogOpen
+                ? ACTIVE_POSTER_TRANSITION_NAME
+                : undefined,
+            visibility: isActive && isDialogOpen ? "hidden" : "visible",
           }}
         >
           <Image src={posterSrc} alt="" isVisible={showImage} />
@@ -101,76 +42,6 @@ export const Movie = ({
           {formats && <FormatList formats={formats} />}
         </span>
       </button>
-
-      <dialog
-        ref={dialogRef}
-        className="movie-dialog"
-        aria-labelledby={titleId}
-        onCancel={(event) => {
-          event.preventDefault();
-          setDialogOpen(false);
-        }}
-        onClick={(event) => {
-          if (event.target === dialogRef.current) {
-            setDialogOpen(false);
-          }
-        }}
-      >
-        <div
-          className="movie-dialog__poster"
-          style={{
-            viewTransitionName: isOpen ? posterTransitionName : undefined,
-          }}
-        >
-          <Image src={posterSrc} alt={title} isVisible={isOpen} />
-        </div>
-        <div className="movie-dialog__content">
-          <button
-            type="button"
-            className="movie-dialog__close"
-            onClick={() => setDialogOpen(false)}
-            aria-label="Close"
-          >
-            &times;
-          </button>
-          <h2 id={titleId}>{title}</h2>
-          {originalTitle && <small>{originalTitle}</small>}
-          {direction && <small>{direction}</small>}
-          <div className="infos">
-            {duration && <Duration value={duration} />}
-            <FormattedDate value={new Date(releaseDate)} />
-            {formats && <FormatList formats={formats} />}
-          </div>
-          {synopsis && <p className="movie-dialog__synopsis">{synopsis}</p>}
-          <div className="movie-dialog__actions">
-            <button
-              type="button"
-              onClick={() => {
-                window.sessionStorage.setItem(
-                  "scrollPos",
-                  movieEltRef.current.offsetTop
-                );
-                navigate(`/movies/${id}/update`);
-              }}
-            >
-              Edit
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                const confirm = window.confirm(
-                  `Are you sure want to delete '${title}' (${direction} - ${releaseDate}) ?`
-                );
-                if (confirm) {
-                  dispatch(remove(id, title));
-                }
-              }}
-            >
-              Delete
-            </button>
-          </div>
-        </div>
-      </dialog>
     </li>
   );
 };

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -12,70 +12,6 @@ import { Image } from "Core";
 import { remove } from "Movie/Actions";
 
 const assetsUrl = process.env.REACT_APP_API_URL;
-const POSTER_FLIP_MS = 280;
-const POSTER_FLIP_EASING = "cubic-bezier(0.2, 0, 0, 1)";
-
-const prefersReducedMotion = () =>
-  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-
-// FLIP (First-Last-Invert-Play): make `el`, which is already at its
-// resting position, appear to start from `fromRect` and animate to
-// rest. Cheap because it only ever transforms this one element.
-const flipFrom = (el, fromRect, onDone) => {
-  if (!el || !fromRect || prefersReducedMotion()) {
-    onDone?.();
-    return;
-  }
-
-  const toRect = el.getBoundingClientRect();
-  const deltaX = fromRect.left - toRect.left;
-  const deltaY = fromRect.top - toRect.top;
-  const scaleX = fromRect.width / toRect.width;
-  const scaleY = fromRect.height / toRect.height;
-
-  el.style.transformOrigin = "top left";
-  el.style.transition = "none";
-  el.style.transform = `translate(${deltaX}px, ${deltaY}px) scale(${scaleX}, ${scaleY})`;
-  el.offsetHeight; // eslint-disable-line no-unused-expressions -- force reflow
-  el.style.transition = `transform ${POSTER_FLIP_MS}ms ${POSTER_FLIP_EASING}`;
-  el.style.transform = "";
-
-  const cleanup = () => {
-    el.style.transition = "";
-    el.style.transformOrigin = "";
-    el.removeEventListener("transitionend", cleanup);
-    onDone?.();
-  };
-  el.addEventListener("transitionend", cleanup, { once: true });
-};
-
-// Reverse of flipFrom: animate `el` from its resting position to look
-// like `targetRect`, then call onDone (typically to hide/close it).
-const flipToward = (el, targetRect, onDone) => {
-  if (!el || !targetRect || prefersReducedMotion()) {
-    onDone?.();
-    return;
-  }
-
-  const fromRect = el.getBoundingClientRect();
-  const deltaX = targetRect.left - fromRect.left;
-  const deltaY = targetRect.top - fromRect.top;
-  const scaleX = targetRect.width / fromRect.width;
-  const scaleY = targetRect.height / fromRect.height;
-
-  el.style.transformOrigin = "top left";
-  el.style.transition = `transform ${POSTER_FLIP_MS}ms ${POSTER_FLIP_EASING}`;
-  el.style.transform = `translate(${deltaX}px, ${deltaY}px) scale(${scaleX}, ${scaleY})`;
-
-  const cleanup = () => {
-    el.style.transition = "";
-    el.style.transformOrigin = "";
-    el.style.transform = "";
-    el.removeEventListener("transitionend", cleanup);
-    onDone?.();
-  };
-  el.addEventListener("transitionend", cleanup, { once: true });
-};
 
 export const Movie = ({
   movie: {
@@ -96,35 +32,36 @@ export const Movie = ({
 
   const movieEltRef = useRef();
   const dialogRef = useRef();
-  const gridPosterRef = useRef();
-  const dialogPosterRef = useRef();
   const [isOpen, setIsOpen] = useState(false);
   const titleId = useId();
 
   const posterSrc = `${assetsUrl}/uploads/${poster}`;
+  const posterTransitionName = `movie-poster-${id}`;
 
-  const openDialog = async () => {
-    const gridRect = gridPosterRef.current.getBoundingClientRect();
+  const setDialogOpen = async (open) => {
+    const applyDomChanges = () => {
+      if (open) {
+        dialogRef.current.showModal();
+      }
+      flushSync(() => setIsOpen(open));
+      if (!open) {
+        dialogRef.current.close();
+      }
+    };
 
-    // Make sure the dialog's poster is decoded before it's shown,
-    // otherwise it would pop in mid-flip.
-    const preload = new window.Image();
-    preload.src = posterSrc;
-    await (preload.decode ? preload.decode().catch(() => {}) : null);
+    if (open) {
+      // Make sure the dialog's poster is already decoded before the
+      // transition captures it, otherwise it briefly snapshots empty.
+      const preload = new window.Image();
+      preload.src = posterSrc;
+      await (preload.decode ? preload.decode().catch(() => {}) : null);
+    }
 
-    dialogRef.current.showModal();
-    flushSync(() => setIsOpen(true));
-
-    flipFrom(dialogPosterRef.current, gridRect);
-  };
-
-  const closeDialog = () => {
-    const gridRect = gridPosterRef.current.getBoundingClientRect();
-
-    flipToward(dialogPosterRef.current, gridRect, () => {
-      dialogRef.current.close();
-      setIsOpen(false);
-    });
+    if (document.startViewTransition) {
+      document.startViewTransition(applyDomChanges);
+    } else {
+      applyDomChanges();
+    }
   };
 
   return (
@@ -134,9 +71,14 @@ export const Movie = ({
         className="movie-item"
         data-item-id={id}
         ref={movieEltRef}
-        onClick={openDialog}
+        onClick={() => setDialogOpen(true)}
       >
-        <span className="movie-item__poster" ref={gridPosterRef}>
+        <span
+          className="movie-item__poster"
+          style={{
+            viewTransitionName: isOpen ? undefined : posterTransitionName,
+          }}
+        >
           <Image src={posterSrc} alt="" isVisible={showImage} />
         </span>
         <span className="movie-item__caption">
@@ -151,22 +93,27 @@ export const Movie = ({
         aria-labelledby={titleId}
         onCancel={(event) => {
           event.preventDefault();
-          closeDialog();
+          setDialogOpen(false);
         }}
         onClick={(event) => {
           if (event.target === dialogRef.current) {
-            closeDialog();
+            setDialogOpen(false);
           }
         }}
       >
-        <div className="movie-dialog__poster" ref={dialogPosterRef}>
+        <div
+          className="movie-dialog__poster"
+          style={{
+            viewTransitionName: isOpen ? posterTransitionName : undefined,
+          }}
+        >
           <Image src={posterSrc} alt={title} isVisible={isOpen} />
         </div>
         <div className="movie-dialog__content">
           <button
             type="button"
             className="movie-dialog__close"
-            onClick={closeDialog}
+            onClick={() => setDialogOpen(false)}
             aria-label="Close"
           >
             &times;

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -39,28 +39,37 @@ export const Movie = ({
   const posterTransitionName = `movie-poster-${id}`;
 
   const setDialogOpen = async (open) => {
-    const applyDomChanges = () => {
-      if (open) {
-        dialogRef.current.showModal();
-      }
-      flushSync(() => setIsOpen(open));
-      if (!open) {
-        dialogRef.current.close();
-      }
-    };
-
     if (open) {
       // Make sure the dialog's poster is already decoded before the
       // transition captures it, otherwise it briefly snapshots empty.
       const preload = new window.Image();
       preload.src = posterSrc;
       await (preload.decode ? preload.decode().catch(() => {}) : null);
+
+      // showModal() promotes the dialog to the browser's top layer.
+      // Do this *before* starting the transition so the transition's
+      // own pseudo-element tree - inserted into the top layer right
+      // after - stacks above it instead of underneath.
+      dialogRef.current.showModal();
+      const applyOpenState = () => flushSync(() => setIsOpen(true));
+
+      if (document.startViewTransition) {
+        document.startViewTransition(applyOpenState);
+      } else {
+        applyOpenState();
+      }
+      return;
     }
 
+    const applyClosedState = () => {
+      flushSync(() => setIsOpen(false));
+      dialogRef.current.close();
+    };
+
     if (document.startViewTransition) {
-      document.startViewTransition(applyDomChanges);
+      document.startViewTransition(applyClosedState);
     } else {
-      applyDomChanges();
+      applyClosedState();
     }
   };
 

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -1,4 +1,5 @@
-import React, { useRef } from "react";
+import React, { useId, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { FormattedDate } from "react-intl";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
@@ -30,53 +31,123 @@ export const Movie = ({
   const navigate = useNavigate();
 
   const movieEltRef = useRef();
+  const dialogRef = useRef();
+  const [isOpen, setIsOpen] = useState(false);
+  const titleId = useId();
+
+  const posterSrc = `${assetsUrl}/uploads/${poster}`;
+  const posterTransitionName = `movie-poster-${id}`;
+
+  const setDialogOpen = (open) => {
+    const applyDomChanges = () => {
+      if (open) {
+        dialogRef.current.showModal();
+      }
+      flushSync(() => setIsOpen(open));
+      if (!open) {
+        dialogRef.current.close();
+      }
+    };
+
+    if (document.startViewTransition) {
+      document.startViewTransition(applyDomChanges);
+    } else {
+      applyDomChanges();
+    }
+  };
 
   return (
-    <div className="movie-item" data-item-id={id} ref={movieEltRef}>
-      <Image
-        src={`${assetsUrl}/uploads/${poster}`}
-        alt={title}
-        isVisible={showImage}
-      />
-      <section className="movie-item__content">
-        <h3>{title}</h3>
-        {originalTitle && <small>{originalTitle}</small>}
-        {direction && <small>{direction}</small>}
-        <section className="infos">
-          {duration && <Duration className="duration" value={duration} />}
-          <FormattedDate
-            className="theater-release-Date"
-            value={new Date(releaseDate)}
-          />
+    <li className="movie-list__item">
+      <button
+        type="button"
+        className="movie-item"
+        data-item-id={id}
+        ref={movieEltRef}
+        onClick={() => setDialogOpen(true)}
+      >
+        <span
+          className="movie-item__poster"
+          style={{
+            viewTransitionName: isOpen ? undefined : posterTransitionName,
+          }}
+        >
+          <Image src={posterSrc} alt="" isVisible={showImage} />
+        </span>
+        <span className="movie-item__caption">
+          <span className="movie-item__title">{title}</span>
           {formats && <FormatList formats={formats} />}
-        </section>
-        <p>{synopsis}</p>
-      </section>
-      <section className="options">
-        <button
-          onClick={() => {
-            navigate(`/movies/${id}/update`);
-            window.sessionStorage.setItem(
-              "scrollPos",
-              movieEltRef.current.offsetTop
-            );
+        </span>
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        className="movie-dialog"
+        aria-labelledby={titleId}
+        onCancel={(event) => {
+          event.preventDefault();
+          setDialogOpen(false);
+        }}
+        onClick={(event) => {
+          if (event.target === dialogRef.current) {
+            setDialogOpen(false);
+          }
+        }}
+      >
+        <div
+          className="movie-dialog__poster"
+          style={{
+            viewTransitionName: isOpen ? posterTransitionName : undefined,
           }}
         >
-          Edit
-        </button>
-        <button
-          onClick={() => {
-            const confirm = window.confirm(
-              `Are you sure want to delete '${title}' (${direction} - ${releaseDate}) ?`
-            );
-            if (confirm) {
-              dispatch(remove(id, title));
-            }
-          }}
-        >
-          Delete
-        </button>
-      </section>
-    </div>
+          <Image src={posterSrc} alt={title} isVisible={isOpen} />
+        </div>
+        <div className="movie-dialog__content">
+          <button
+            type="button"
+            className="movie-dialog__close"
+            onClick={() => setDialogOpen(false)}
+            aria-label="Close"
+          >
+            &times;
+          </button>
+          <h2 id={titleId}>{title}</h2>
+          {originalTitle && <small>{originalTitle}</small>}
+          {direction && <small>{direction}</small>}
+          <div className="infos">
+            {duration && <Duration value={duration} />}
+            <FormattedDate value={new Date(releaseDate)} />
+            {formats && <FormatList formats={formats} />}
+          </div>
+          {synopsis && <p className="movie-dialog__synopsis">{synopsis}</p>}
+          <div className="movie-dialog__actions">
+            <button
+              type="button"
+              onClick={() => {
+                window.sessionStorage.setItem(
+                  "scrollPos",
+                  movieEltRef.current.offsetTop
+                );
+                navigate(`/movies/${id}/update`);
+              }}
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const confirm = window.confirm(
+                  `Are you sure want to delete '${title}' (${direction} - ${releaseDate}) ?`
+                );
+                if (confirm) {
+                  dispatch(remove(id, title));
+                }
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      </dialog>
+    </li>
   );
 };

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -49,11 +49,16 @@ export const Movie = ({
       // showModal() promotes the dialog to the browser's top layer.
       // Do this *before* starting the transition so the transition's
       // own pseudo-element tree - inserted into the top layer right
-      // after - stacks above it instead of underneath.
+      // after - stacks above it instead of underneath. Give the
+      // browser a full frame to settle that promotion first, so it
+      // isn't racing the transition's own setup within the same task.
       dialogRef.current.showModal();
       const applyOpenState = () => flushSync(() => setIsOpen(true));
 
       if (document.startViewTransition) {
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve))
+        );
         document.startViewTransition(applyOpenState);
       } else {
         applyOpenState();

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -38,7 +38,7 @@ export const Movie = ({
   const posterSrc = `${assetsUrl}/uploads/${poster}`;
   const posterTransitionName = `movie-poster-${id}`;
 
-  const setDialogOpen = (open) => {
+  const setDialogOpen = async (open) => {
     const applyDomChanges = () => {
       if (open) {
         dialogRef.current.showModal();
@@ -48,6 +48,14 @@ export const Movie = ({
         dialogRef.current.close();
       }
     };
+
+    if (open) {
+      // Make sure the dialog's poster is already decoded before the
+      // transition captures it, otherwise it briefly snapshots empty.
+      const preload = new window.Image();
+      preload.src = posterSrc;
+      await (preload.decode ? preload.decode().catch(() => {}) : null);
+    }
 
     if (document.startViewTransition) {
       document.startViewTransition(applyDomChanges);

--- a/src/Movie/components/Movie.jsx
+++ b/src/Movie/components/Movie.jsx
@@ -12,6 +12,70 @@ import { Image } from "Core";
 import { remove } from "Movie/Actions";
 
 const assetsUrl = process.env.REACT_APP_API_URL;
+const POSTER_FLIP_MS = 280;
+const POSTER_FLIP_EASING = "cubic-bezier(0.2, 0, 0, 1)";
+
+const prefersReducedMotion = () =>
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+// FLIP (First-Last-Invert-Play): make `el`, which is already at its
+// resting position, appear to start from `fromRect` and animate to
+// rest. Cheap because it only ever transforms this one element.
+const flipFrom = (el, fromRect, onDone) => {
+  if (!el || !fromRect || prefersReducedMotion()) {
+    onDone?.();
+    return;
+  }
+
+  const toRect = el.getBoundingClientRect();
+  const deltaX = fromRect.left - toRect.left;
+  const deltaY = fromRect.top - toRect.top;
+  const scaleX = fromRect.width / toRect.width;
+  const scaleY = fromRect.height / toRect.height;
+
+  el.style.transformOrigin = "top left";
+  el.style.transition = "none";
+  el.style.transform = `translate(${deltaX}px, ${deltaY}px) scale(${scaleX}, ${scaleY})`;
+  el.offsetHeight; // eslint-disable-line no-unused-expressions -- force reflow
+  el.style.transition = `transform ${POSTER_FLIP_MS}ms ${POSTER_FLIP_EASING}`;
+  el.style.transform = "";
+
+  const cleanup = () => {
+    el.style.transition = "";
+    el.style.transformOrigin = "";
+    el.removeEventListener("transitionend", cleanup);
+    onDone?.();
+  };
+  el.addEventListener("transitionend", cleanup, { once: true });
+};
+
+// Reverse of flipFrom: animate `el` from its resting position to look
+// like `targetRect`, then call onDone (typically to hide/close it).
+const flipToward = (el, targetRect, onDone) => {
+  if (!el || !targetRect || prefersReducedMotion()) {
+    onDone?.();
+    return;
+  }
+
+  const fromRect = el.getBoundingClientRect();
+  const deltaX = targetRect.left - fromRect.left;
+  const deltaY = targetRect.top - fromRect.top;
+  const scaleX = targetRect.width / fromRect.width;
+  const scaleY = targetRect.height / fromRect.height;
+
+  el.style.transformOrigin = "top left";
+  el.style.transition = `transform ${POSTER_FLIP_MS}ms ${POSTER_FLIP_EASING}`;
+  el.style.transform = `translate(${deltaX}px, ${deltaY}px) scale(${scaleX}, ${scaleY})`;
+
+  const cleanup = () => {
+    el.style.transition = "";
+    el.style.transformOrigin = "";
+    el.style.transform = "";
+    el.removeEventListener("transitionend", cleanup);
+    onDone?.();
+  };
+  el.addEventListener("transitionend", cleanup, { once: true });
+};
 
 export const Movie = ({
   movie: {
@@ -32,36 +96,35 @@ export const Movie = ({
 
   const movieEltRef = useRef();
   const dialogRef = useRef();
+  const gridPosterRef = useRef();
+  const dialogPosterRef = useRef();
   const [isOpen, setIsOpen] = useState(false);
   const titleId = useId();
 
   const posterSrc = `${assetsUrl}/uploads/${poster}`;
-  const posterTransitionName = `movie-poster-${id}`;
 
-  const setDialogOpen = async (open) => {
-    const applyDomChanges = () => {
-      if (open) {
-        dialogRef.current.showModal();
-      }
-      flushSync(() => setIsOpen(open));
-      if (!open) {
-        dialogRef.current.close();
-      }
-    };
+  const openDialog = async () => {
+    const gridRect = gridPosterRef.current.getBoundingClientRect();
 
-    if (open) {
-      // Make sure the dialog's poster is already decoded before the
-      // transition captures it, otherwise it briefly snapshots empty.
-      const preload = new window.Image();
-      preload.src = posterSrc;
-      await (preload.decode ? preload.decode().catch(() => {}) : null);
-    }
+    // Make sure the dialog's poster is decoded before it's shown,
+    // otherwise it would pop in mid-flip.
+    const preload = new window.Image();
+    preload.src = posterSrc;
+    await (preload.decode ? preload.decode().catch(() => {}) : null);
 
-    if (document.startViewTransition) {
-      document.startViewTransition(applyDomChanges);
-    } else {
-      applyDomChanges();
-    }
+    dialogRef.current.showModal();
+    flushSync(() => setIsOpen(true));
+
+    flipFrom(dialogPosterRef.current, gridRect);
+  };
+
+  const closeDialog = () => {
+    const gridRect = gridPosterRef.current.getBoundingClientRect();
+
+    flipToward(dialogPosterRef.current, gridRect, () => {
+      dialogRef.current.close();
+      setIsOpen(false);
+    });
   };
 
   return (
@@ -71,14 +134,9 @@ export const Movie = ({
         className="movie-item"
         data-item-id={id}
         ref={movieEltRef}
-        onClick={() => setDialogOpen(true)}
+        onClick={openDialog}
       >
-        <span
-          className="movie-item__poster"
-          style={{
-            viewTransitionName: isOpen ? undefined : posterTransitionName,
-          }}
-        >
+        <span className="movie-item__poster" ref={gridPosterRef}>
           <Image src={posterSrc} alt="" isVisible={showImage} />
         </span>
         <span className="movie-item__caption">
@@ -93,27 +151,22 @@ export const Movie = ({
         aria-labelledby={titleId}
         onCancel={(event) => {
           event.preventDefault();
-          setDialogOpen(false);
+          closeDialog();
         }}
         onClick={(event) => {
           if (event.target === dialogRef.current) {
-            setDialogOpen(false);
+            closeDialog();
           }
         }}
       >
-        <div
-          className="movie-dialog__poster"
-          style={{
-            viewTransitionName: isOpen ? posterTransitionName : undefined,
-          }}
-        >
+        <div className="movie-dialog__poster" ref={dialogPosterRef}>
           <Image src={posterSrc} alt={title} isVisible={isOpen} />
         </div>
         <div className="movie-dialog__content">
           <button
             type="button"
             className="movie-dialog__close"
-            onClick={() => setDialogOpen(false)}
+            onClick={closeDialog}
             aria-label="Close"
           >
             &times;

--- a/src/Movie/components/MovieDialog.jsx
+++ b/src/Movie/components/MovieDialog.jsx
@@ -1,0 +1,106 @@
+import React, { useId } from "react";
+import { createPortal } from "react-dom";
+import { FormattedDate } from "react-intl";
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+
+import { FormatList } from "Format";
+import { Duration } from "Duration";
+import { Image } from "Core";
+import { remove } from "Movie/Actions";
+import { ACTIVE_POSTER_TRANSITION_NAME } from "Movie/components/Movie";
+
+const assetsUrl = process.env.REACT_APP_API_URL;
+
+export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const titleId = useId();
+
+  return createPortal(
+    <dialog
+      ref={dialogRef}
+      className="movie-dialog"
+      aria-labelledby={movie ? titleId : undefined}
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) {
+          onClose();
+        }
+      }}
+    >
+      {movie && (
+        <>
+          <div
+            className="movie-dialog__poster"
+            style={{
+              viewTransitionName: isOpen
+                ? ACTIVE_POSTER_TRANSITION_NAME
+                : undefined,
+            }}
+          >
+            <Image
+              src={`${assetsUrl}/uploads/${movie.poster}`}
+              alt={movie.title}
+              isVisible={isOpen}
+            />
+          </div>
+          <div className="movie-dialog__content">
+            <button
+              type="button"
+              className="movie-dialog__close"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              &times;
+            </button>
+            <h2 id={titleId}>{movie.title}</h2>
+            {movie.originalTitle && <small>{movie.originalTitle}</small>}
+            {movie.direction && <small>{movie.direction}</small>}
+            <div className="infos">
+              {movie.duration && <Duration value={movie.duration} />}
+              <FormattedDate value={new Date(movie.releaseDate)} />
+              {movie.formats && <FormatList formats={movie.formats} />}
+            </div>
+            {movie.synopsis && (
+              <p className="movie-dialog__synopsis">{movie.synopsis}</p>
+            )}
+            <div className="movie-dialog__actions">
+              <button
+                type="button"
+                onClick={() => {
+                  const tile = document.querySelector(
+                    `[data-item-id="${movie.id}"]`
+                  );
+                  if (tile) {
+                    window.sessionStorage.setItem("scrollPos", tile.offsetTop);
+                  }
+                  navigate(`/movies/${movie.id}/update`);
+                }}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const confirm = window.confirm(
+                    `Are you sure want to delete '${movie.title}' (${movie.direction} - ${movie.releaseDate}) ?`
+                  );
+                  if (confirm) {
+                    dispatch(remove(movie.id, movie.title));
+                  }
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </dialog>,
+    document.body
+  );
+};

--- a/src/Movie/components/MovieDialog.jsx
+++ b/src/Movie/components/MovieDialog.jsx
@@ -34,19 +34,28 @@ export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
     >
       {movie && (
         <>
-          <div
-            className="movie-dialog__poster"
-            style={{
-              viewTransitionName: isOpen
-                ? ACTIVE_POSTER_TRANSITION_NAME
-                : undefined,
-            }}
-          >
-            <Image
-              src={`${assetsUrl}/uploads/${movie.poster}`}
-              alt={movie.title}
-              isVisible={isOpen}
-            />
+          <div className="movie-dialog__poster">
+            <div className="movie-dialog__poster-backdrop" aria-hidden="true">
+              <Image
+                src={`${assetsUrl}/uploads/${movie.poster}`}
+                alt=""
+                isVisible={isOpen}
+              />
+            </div>
+            <div
+              className="movie-dialog__poster-frame"
+              style={{
+                viewTransitionName: isOpen
+                  ? ACTIVE_POSTER_TRANSITION_NAME
+                  : undefined,
+              }}
+            >
+              <Image
+                src={`${assetsUrl}/uploads/${movie.poster}`}
+                alt={movie.title}
+                isVisible={isOpen}
+              />
+            </div>
           </div>
           <div className="movie-dialog__content">
             <button

--- a/src/Movie/components/MovieList.css
+++ b/src/Movie/components/MovieList.css
@@ -9,6 +9,8 @@
 
 .movie-list__item {
   min-width: 0;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 280px;
 }
 
 @media all and (min-width: 500px) {

--- a/src/Movie/components/MovieList.css
+++ b/src/Movie/components/MovieList.css
@@ -1,18 +1,24 @@
 .movie-list {
   display: grid;
-  grid-row-gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.movie-list__item {
+  min-width: 0;
 }
 
 @media all and (min-width: 500px) {
   .movie-list {
     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    grid-gap: 10px;
-    grid-template-rows: initial;
   }
 }
 
 @media all and (min-width: 980px) {
   .movie-list {
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 }

--- a/src/Movie/components/MovieList.jsx
+++ b/src/Movie/components/MovieList.jsx
@@ -1,13 +1,19 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import "./MovieList.css";
 
 import { Movie } from "Movie/components/Movie";
+import { MovieDialog } from "Movie/components/MovieDialog";
 
+const assetsUrl = process.env.REACT_APP_API_URL;
 let timeoutID = null;
 
 export const MovieList = ({ movies }) => {
   const bottomBoundary = window.innerHeight;
   const [moviesInViewport, setMoviesInViewport] = useState([]);
+  const [selectedMovie, setSelectedMovie] = useState(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const dialogRef = useRef();
 
   const toggleImages = useCallback(() => {
     clearTimeout(timeoutID);
@@ -42,17 +48,65 @@ export const MovieList = ({ movies }) => {
     };
   }, [toggleImages]);
 
+  const selectMovie = async (movie) => {
+    // Make sure the dialog's poster is already decoded before the
+    // transition captures it, otherwise it briefly snapshots empty.
+    const preload = new window.Image();
+    preload.src = `${assetsUrl}/uploads/${movie.poster}`;
+    await (preload.decode ? preload.decode().catch(() => {}) : null);
+
+    flushSync(() => setSelectedMovie(movie));
+
+    const openDialog = () => {
+      dialogRef.current.showModal();
+      flushSync(() => setIsDialogOpen(true));
+    };
+
+    if (document.startViewTransition) {
+      document.startViewTransition(openDialog);
+    } else {
+      openDialog();
+    }
+  };
+
+  const closeDialog = () => {
+    const applyClosedState = () => {
+      flushSync(() => setIsDialogOpen(false));
+      dialogRef.current.close();
+    };
+
+    if (document.startViewTransition) {
+      document
+        .startViewTransition(applyClosedState)
+        .finished.finally(() => setSelectedMovie(null));
+    } else {
+      applyClosedState();
+      setSelectedMovie(null);
+    }
+  };
+
   return (
-    <ul className="movie-list">
-      {movies.map((movie) => {
-        return (
-          <Movie
-            key={movie.id}
-            movie={movie}
-            showImage={moviesInViewport.includes(movie.id)}
-          />
-        );
-      })}
-    </ul>
+    <>
+      <ul className="movie-list">
+        {movies.map((movie) => {
+          return (
+            <Movie
+              key={movie.id}
+              movie={movie}
+              showImage={moviesInViewport.includes(movie.id)}
+              isActive={selectedMovie?.id === movie.id}
+              isDialogOpen={isDialogOpen}
+              onSelect={() => selectMovie(movie)}
+            />
+          );
+        })}
+      </ul>
+      <MovieDialog
+        dialogRef={dialogRef}
+        movie={selectedMovie}
+        isOpen={isDialogOpen}
+        onClose={closeDialog}
+      />
+    </>
   );
 };

--- a/src/Movie/components/MovieList.jsx
+++ b/src/Movie/components/MovieList.jsx
@@ -43,7 +43,7 @@ export const MovieList = ({ movies }) => {
   }, [toggleImages]);
 
   return (
-    <div className="movie-list">
+    <ul className="movie-list">
       {movies.map((movie) => {
         return (
           <Movie
@@ -53,6 +53,6 @@ export const MovieList = ({ movies }) => {
           />
         );
       })}
-    </div>
+    </ul>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,11 @@
   --color-overlay: rgb(0 0 0 / 60%);
   --color-shadow: rgb(0 0 0 / 45%);
 
+  /* Neutral backing plate for third-party logos (format badges, ...)
+     whose own artwork isn't guaranteed to have contrast against a
+     dark surface. */
+  --color-badge-bg: #fff;
+
   --radius-sm: 4px;
   --radius-md: 8px;
 }

--- a/test/setup-matchers.js
+++ b/test/setup-matchers.js
@@ -1,0 +1,7 @@
+import { afterEach } from "bun:test";
+import { cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+afterEach(() => {
+  cleanup();
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();


### PR DESCRIPTION
## Summary
- Replace the desktop-tile/mobile-row split with a single poster-tile grid at every breakpoint (media queries only tune column count). Each tile shows just the title and owned formats over the poster.
- Everything else (original title, director, duration, release date, synopsis, edit/delete) moves into a single, portal-rendered `<dialog>` (`createPortal(document.body)`), driven by a "selected movie" state lifted into `MovieList`.
- The poster morphs from its grid position into the dialog using the View Transitions API (feature-detected, graceful no-op fallback). Container queries drive two independent size-based adaptations: the tile's own title sizing in the fluid grid, and the dialog's info-row layout based on the dialog's own width — decoupled from the viewport-driven media queries that shape the grid/dialog overall.
- `content-visibility: auto` on grid items, since the page loads all ~850 movies into the DOM at once; this is what actually fixed the transition jank, not the various stacking-order attempts along the way (kept the useful ones: exact 27:40 poster aspect ratio, dialog height capped to the poster instead of stretching for long synopses, mobile poster capped to 280px with a blurred ambient backdrop filling the rest).
- Format badges get a white backing plate (their logos aren't guaranteed to have contrast on a dark surface) except the 4K badge, whose logo is already yellow and only needs an outline.
- Bonus: migrated the 3 dead Enzyme specs (enzyme itself isn't even installed, and its React 16 adapter can't run under React 19) to `@testing-library/react`, with a `happy-dom` environment wired into `bun test`.

## Test plan
- [x] Verified repeatedly on the live local instance (850 movies) — desktop and mobile, grid density, dialog open/close via tap/click, close button, backdrop click, and Escape
- [x] `bunx eslint --max-warnings=0` clean on all changed files
- [x] `bun test` — 4/4 pass (was 1/4 with 3 broken Enzyme specs before this branch)