### PR TITLE
fix: resolve pre-existing eslint errors blocking --max-warnings=0

### DIFF
--- a/src/Core/components/FlashMessage/FlashMessage.css
+++ b/src/Core/components/FlashMessage/FlashMessage.css
@@ -9,13 +9,13 @@
   color: var(--color-text-primary);
 }
 
-.flash-message-container[status="success"] {
+.flash-message-container[data-status="success"] {
   color: var(--color-bg);
   font-weight: 600;
   background-color: var(--color-accent);
 }
 
-.flash-message-container[status="failure"] {
+.flash-message-container[data-status="failure"] {
   color: var(--color-bg);
   font-weight: 600;
   background-color: var(--color-danger);

--- a/src/Core/components/FlashMessage/FlashMessage.js
+++ b/src/Core/components/FlashMessage/FlashMessage.js
@@ -9,7 +9,7 @@ export const FlashMessage = () => {
   const status = useSelector(selectFlashStatus);
 
   return (
-    <div className="flash-message-container" status={status}>
+    <div className="flash-message-container" data-status={status}>
       <p>{message}</p>
     </div>
   );

--- a/src/Duration/DurationFormatter.spec.js
+++ b/src/Duration/DurationFormatter.spec.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { toHourMin } from "./DurationFormatter";
 
 test("toHourMin must convert a minute only value to [x]h[y]min", () => {

--- a/src/Format/FormatCheckboxGroup.js
+++ b/src/Format/FormatCheckboxGroup.js
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 export const FormatCheckboxGroup = ({ initialValues, formats, onChange }) => {
   const [values, setValues] = useState(initialValues || []);
+  const [syncedInitialValues, setSyncedInitialValues] = useState(initialValues);
 
-  useEffect(() => {
-    if (initialValues) {
-      setValues(initialValues);
-    }
-  }, [initialValues]);
+  if (initialValues && initialValues !== syncedInitialValues) {
+    setSyncedInitialValues(initialValues);
+    setValues(initialValues);
+  }
 
   const changeHandler = (event) => {
     const { value: selection } = event.target;

--- a/src/Log/reducer.js
+++ b/src/Log/reducer.js
@@ -1,12 +1,12 @@
 import {
   FETCH_LOG_LIST_PENDING,
   FETCH_LOG_LIST_SUCCESS,
-  FETCH_LOG_LIST_FAILURE
+  FETCH_LOG_LIST_FAILURE,
 } from "./actionTypes";
 
 const initialState = {
   isFetching: false,
-  history: []
+  history: [],
 };
 
 const logReducer = (state = initialState, action) => {
@@ -14,19 +14,20 @@ const logReducer = (state = initialState, action) => {
     case FETCH_LOG_LIST_PENDING:
       return {
         ...state,
-        isFetching: true
+        isFetching: true,
       };
-    case FETCH_LOG_LIST_SUCCESS:
+    case FETCH_LOG_LIST_SUCCESS: {
       const { history } = action.payload;
       return {
         ...state,
         history,
-        isFetching: false
+        isFetching: false,
       };
+    }
     case FETCH_LOG_LIST_FAILURE:
       return {
         ...state,
-        isFetching: false
+        isFetching: false,
       };
     default:
       return state;

--- a/src/Movie/MovieRouter.js
+++ b/src/Movie/MovieRouter.js
@@ -3,7 +3,7 @@ import { Route, Routes } from "react-router-dom";
 import { CreationPage } from "./pages/CreationPage";
 import { UpdatePage } from "./pages/UpdatePage";
 
-const MovieRouter = ({ match }) => (
+const MovieRouter = () => (
   <Routes>
     <Route exact path="create" element={<CreationPage />} />
     <Route path=":id/update" element={<UpdatePage />} />


### PR DESCRIPTION
## Summary
- Fixes 5 pre-existing `bunx eslint src --max-warnings=0` errors, unrelated to the home/dialog UI work in progress
- `FlashMessage.js` / `FlashMessage.css`: `status` DOM prop → `data-status` attribute (with matching CSS selector update)
- `DurationFormatter.spec.js`: removed unused `React` import
- `FormatCheckboxGroup.js`: replaced effect-based state sync with React's render-time state-adjustment pattern (initialValues can arrive asynchronously, e.g. when editing a movie fetched after mount)
- `reducer.js`: wrapped `case` body in a block to scope the lexical declaration
- `MovieRouter.js`: removed unused `match` param

## Test plan
- [x] `bunx eslint src --max-warnings=0` passes with zero errors
- [x] `bun test` — no new failures (3 pre-existing `enzyme`-related failures reproduced identically on `master`)