### PR TITLE
Movie deletion: inline arm/confirm button replacing native confirm()

### DIFF
--- a/src/Movie/Actions.js
+++ b/src/Movie/Actions.js
@@ -161,7 +161,7 @@ const remove = (id, title) => {
       flashMessage: `'${title}' has been deleted successfully.`,
     };
 
-    GraphQLClient.mutate({
+    return GraphQLClient.mutate({
       mutation: mutations.DELETE_MOVIE,
       variables: {
         id: parseInt(id),

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -147,7 +147,10 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  padding: 20px;
+  /* Extra clearance so scrolled content never sits under the delete
+     button, which floats over the dialog rather than scrolling with
+     this pane. */
+  padding: 20px 20px 56px;
 }
 
 .movie-dialog__close {
@@ -209,18 +212,59 @@
   height: 44px;
   border: 0;
   border-radius: var(--radius-sm);
+  background-color: var(--color-info);
   color: var(--color-text-primary);
   font-size: 15px;
   font-weight: 600;
   cursor: pointer;
 }
 
-.movie-dialog__actions button:first-child {
-  background-color: var(--color-info);
+/* Deliberately understated next to Edit: an outline that fills in
+   only once the user confirms, rather than a same-weight red button
+   sitting right next to the primary action. Floats over the dialog
+   (not the scrollable content pane) so it stays put, bottom-center
+   on the mobile full page and bottom-right once the dialog is a
+   floating card on desktop. */
+.movie-dialog__delete {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  z-index: 1;
+  overflow: hidden;
+  padding: 0 16px;
+  height: 36px;
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-sm);
+  background-color: transparent;
+  color: var(--color-danger);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transform: translateX(-50%);
+  /* Kept in sync with the fill below: the button's onTransitionEnd
+     handler listens for this color transition to know the fill has
+     finished, so a confirm click is only accepted once it's visibly
+     complete. */
+  transition: color 0.7s ease;
 }
 
-.movie-dialog__actions button:last-child {
+.movie-dialog__delete::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
   background-color: var(--color-danger);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.7s ease;
+}
+
+.movie-dialog__delete--confirming {
+  color: var(--color-text-primary);
+}
+
+.movie-dialog__delete--confirming::before {
+  transform: scaleX(1);
 }
 
 @media all and (min-width: 768px) {
@@ -238,6 +282,12 @@
     flex: 0 0 280px;
     align-self: flex-start;
     height: auto;
+  }
+
+  .movie-dialog__delete {
+    left: auto;
+    right: 16px;
+    transform: none;
   }
 }
 

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -222,13 +222,12 @@
 /* Deliberately understated next to Edit: an outline that fills in
    only once the user confirms, rather than a same-weight red button
    sitting right next to the primary action. Floats over the dialog
-   (not the scrollable content pane) so it stays put, bottom-center
-   on the mobile full page and bottom-right once the dialog is a
-   floating card on desktop. */
+   (not the scrollable content pane) so it stays put, bottom-right on
+   both the mobile full page and the desktop floating card. */
 .movie-dialog__delete {
   position: absolute;
+  right: 16px;
   bottom: 16px;
-  left: 50%;
   z-index: 1;
   overflow: hidden;
   padding: 0 16px;
@@ -240,7 +239,6 @@
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transform: translateX(-50%);
   /* Kept in sync with the fill below: the button's onTransitionEnd
      handler listens for this color transition to know the fill has
      finished, so a confirm click is only accepted once it's visibly
@@ -255,7 +253,7 @@
   z-index: -1;
   background-color: var(--color-danger);
   transform: scaleX(0);
-  transform-origin: left;
+  transform-origin: right;
   transition: transform 0.7s ease;
 }
 
@@ -282,12 +280,6 @@
     flex: 0 0 280px;
     align-self: flex-start;
     height: auto;
-  }
-
-  .movie-dialog__delete {
-    left: auto;
-    right: 16px;
-    transform: none;
   }
 }
 

--- a/src/Movie/components/MovieDialog.jsx
+++ b/src/Movie/components/MovieDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useId } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { FormattedDate } from "react-intl";
 import { useNavigate } from "react-router-dom";
@@ -16,6 +16,39 @@ export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const titleId = useId();
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  // The fill animation must finish before a click actually confirms,
+  // otherwise a fast double-click deletes before the user sees it arm.
+  const [readyToConfirm, setReadyToConfirm] = useState(false);
+  const [confirmingForMovieId, setConfirmingForMovieId] = useState(movie?.id);
+  const deleteButtonRef = useRef(null);
+
+  const resetConfirmation = () => {
+    setConfirmingDelete(false);
+    setReadyToConfirm(false);
+  };
+
+  // A movie change (new selection, or the dialog closing) always
+  // means the previous confirmation no longer applies.
+  if (movie?.id !== confirmingForMovieId) {
+    setConfirmingForMovieId(movie?.id);
+    resetConfirmation();
+  }
+
+  useEffect(() => {
+    if (!confirmingDelete) {
+      return undefined;
+    }
+
+    const handleOutsideClick = (event) => {
+      if (!deleteButtonRef.current?.contains(event.target)) {
+        resetConfirmation();
+      }
+    };
+
+    document.addEventListener("click", handleOutsideClick);
+    return () => document.removeEventListener("click", handleOutsideClick);
+  }, [confirmingDelete]);
 
   return createPortal(
     <dialog
@@ -92,21 +125,38 @@ export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
               >
                 Edit
               </button>
-              <button
-                type="button"
-                onClick={() => {
-                  const confirm = window.confirm(
-                    `Are you sure want to delete '${movie.title}' (${movie.direction} - ${movie.releaseDate}) ?`
-                  );
-                  if (confirm) {
-                    dispatch(remove(movie.id, movie.title));
-                  }
-                }}
-              >
-                Delete
-              </button>
             </div>
           </div>
+          <button
+            ref={deleteButtonRef}
+            type="button"
+            className={
+              confirmingDelete
+                ? "movie-dialog__delete movie-dialog__delete--confirming"
+                : "movie-dialog__delete"
+            }
+            onClick={async () => {
+              if (!confirmingDelete) {
+                setConfirmingDelete(true);
+                return;
+              }
+              if (!readyToConfirm) {
+                return;
+              }
+              await dispatch(remove(movie.id, movie.title));
+              onClose();
+            }}
+            onTransitionEnd={(event) => {
+              if (
+                event.target === event.currentTarget &&
+                event.propertyName === "color"
+              ) {
+                setReadyToConfirm(true);
+              }
+            }}
+          >
+            {confirmingDelete ? "Confirm deletion" : "Delete"}
+          </button>
         </>
       )}
     </dialog>,


### PR DESCRIPTION
## Summary
- The delete control in the movie detail dialog is now a discreet outlined red button, positioned bottom-right of the dialog (desktop) and bottom-right of the full page (mobile), instead of a same-weight filled button sitting next to Edit.
- Replaces the native `window.confirm()` (not stylable) with an inline two-step confirmation: a first click arms the button — it fills red right-to-left with an animation and its label changes to "Confirm deletion" — and only a second click, once that fill animation has actually finished, triggers deletion. This prevents a fast double-click from deleting before the user sees the confirmation state.
- Clicking anywhere else in the dialog disarms the button back to its initial state.
- On successful deletion the dialog closes.
- `Movie/Actions.js`: `remove()` now returns its mutation promise so the caller can await completion before closing.

## Test plan
- [x] `bunx eslint --max-warnings=0`
- [x] `bun test`
- [x] Verified live on desktop and mobile viewports: arm/confirm flow, fast double-click doesn't delete prematurely, clicking outside the button resets it without closing the dialog, successful deletion closes the dialog and updates the grid, fill animation direction and button position on both breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)