### PR TITLE
Movie editing: open new movie's detail view, inline desktop edit, validation

### DIFF
--- a/src/Movie/Actions.js
+++ b/src/Movie/Actions.js
@@ -105,7 +105,7 @@ const update = ({ id, title, direction, releaseDate, poster, formats }) => {
       type: MOVIE_UPDATE_PENDING,
     });
 
-    GraphQLClient.mutate({
+    return GraphQLClient.mutate({
       mutation: mutations.UPDATE_MOVIE,
       variables: {
         id: parseInt(id),
@@ -130,6 +130,8 @@ const update = ({ id, title, direction, releaseDate, poster, formats }) => {
           movie,
           flashMessage: `'${title}' has been updated successfully.`,
         });
+
+        return movie;
       })
       .catch((error) => {
         if (error.graphQLErrors[0]?.extensions?.code === 404) {

--- a/src/Movie/components/Form.jsx
+++ b/src/Movie/components/Form.jsx
@@ -18,6 +18,14 @@ import { DESKTOP_QUERY } from "Movie/constants";
 const SEARCH_MIN_LENGTH = 3;
 const SEARCH_DEBOUNCE_MS = 400;
 
+const areFormatsEqual = (a = [], b = []) => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const idsA = new Set(a.map((format) => String(format.id)));
+  return b.every((format) => idsA.has(String(format.id)));
+};
+
 export const Form = ({ onSubmit, initialValues, isUpdate }) => {
   const dispatch = useDispatch();
   const proposals = useSelector(selectProposalList);
@@ -36,6 +44,13 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
     !!(movie.direction || "").trim() &&
     !!movie.releaseDate &&
     (movie.formats || []).length > 0;
+
+  const hasChanged =
+    (movie.title || "") !== (initialValues?.title || "") ||
+    (movie.direction || "") !== (initialValues?.direction || "") ||
+    (movie.releaseDate || "") !== (initialValues?.releaseDate || "") ||
+    movie.poster !== initialValues?.poster ||
+    !areFormatsEqual(movie.formats || [], initialValues?.formats || []);
 
   useEffect(() => {
     if (formats.length === 0) {
@@ -164,7 +179,7 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
           <button
             type="submit"
             className="movie-form__submit"
-            disabled={!isComplete}
+            disabled={!isComplete || !hasChanged}
           >
             {initialValues ? "Update" : "Create"}
           </button>

--- a/src/Movie/components/Form.jsx
+++ b/src/Movie/components/Form.jsx
@@ -30,16 +30,12 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
 
   const formats = useSelector(selectFormatList);
 
-  // Only enforced on creation: existing movies may already be missing
-  // a field, and disabling Update for them would block fixing anything
-  // else about the record until that unrelated field is backfilled.
   const isComplete =
     !!movie.poster &&
     !!(movie.title || "").trim() &&
     !!(movie.direction || "").trim() &&
     !!movie.releaseDate &&
     (movie.formats || []).length > 0;
-  const canSubmit = isUpdate || isComplete;
 
   useEffect(() => {
     if (formats.length === 0) {
@@ -48,7 +44,7 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
   });
 
   useEffect(() => {
-    if (!isDesktop) {
+    if (!isDesktop || isUpdate) {
       return undefined;
     }
 
@@ -79,7 +75,7 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
     }, SEARCH_DEBOUNCE_MS);
 
     return () => clearTimeout(timeoutId);
-  }, [isDesktop, movie.title, movie.direction, dispatch]);
+  }, [isDesktop, isUpdate, movie.title, movie.direction, dispatch]);
 
   return (
     <>
@@ -112,14 +108,14 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
                 name="title"
                 type="text"
                 placeholder=" "
-                required={!isUpdate}
+                required
                 value={movie.title || ""}
                 onChange={({ currentTarget: { value: title } }) =>
                   setMovie({ ...movie, title })
                 }
               />
               <label htmlFor="title">Title</label>
-              {!isDesktop && movie.title && (
+              {!isDesktop && !isUpdate && movie.title && (
                 <button
                   type="button"
                   className="movie-form__search"
@@ -135,7 +131,7 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
                 name="direction"
                 type="text"
                 placeholder=" "
-                required={!isUpdate}
+                required
                 value={movie.direction || ""}
                 onChange={({ currentTarget: { value: direction } }) =>
                   setMovie({ ...movie, direction })
@@ -149,7 +145,7 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
                 name="releaseDate"
                 type="date"
                 placeholder=" "
-                required={!isUpdate}
+                required
                 value={movie.releaseDate || ""}
                 onChange={({ currentTarget: { value: releaseDate } }) =>
                   setMovie({ ...movie, releaseDate })
@@ -168,20 +164,22 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
           <button
             type="submit"
             className="movie-form__submit"
-            disabled={!canSubmit}
+            disabled={!isComplete}
           >
             {initialValues ? "Update" : "Create"}
           </button>
         </div>
       </form>
-      <SuggestionsPanel
-        proposals={proposals}
-        onSelect={(proposal) => {
-          skipNextSearchRef.current = true;
-          setMovie({ ...movie, ...proposal });
-          dispatch(resetProposalList());
-        }}
-      />
+      {!isUpdate && (
+        <SuggestionsPanel
+          proposals={proposals}
+          onSelect={(proposal) => {
+            skipNextSearchRef.current = true;
+            setMovie({ ...movie, ...proposal });
+            dispatch(resetProposalList());
+          }}
+        />
+      )}
     </>
   );
 };

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -147,25 +147,60 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  /* Extra clearance so scrolled content never sits under the delete
+  /* Top clearance for the back chevron (mobile only - see below);
+     bottom clearance so scrolled content never sits under the delete
      button, which floats over the dialog rather than scrolling with
      this pane. */
-  padding: 20px 20px 56px;
+  padding: 56px 20px 56px;
 }
 
+/* Mobile: this reads as a dedicated page rather than a dialog, so
+   the control is a plain back chevron - no pill/background - same
+   treatment as the creation and update pages' own back control. */
 .movie-dialog__close {
   position: absolute;
   top: 12px;
-  right: 12px;
+  left: 12px;
+  z-index: 1;
   width: 32px;
   height: 32px;
+  padding: 0;
   border: 0;
-  border-radius: 50%;
-  background-color: var(--color-overlay);
-  color: var(--color-text-primary);
-  font-size: 18px;
-  line-height: 1;
+  background: none;
   cursor: pointer;
+}
+
+.movie-dialog__close::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  width: 10px;
+  height: 10px;
+  border-left: 2px solid var(--color-text-primary);
+  border-bottom: 2px solid var(--color-text-primary);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+@media all and (min-width: 768px) {
+  .movie-dialog__close {
+    top: 12px;
+    left: auto;
+    right: 12px;
+    border-radius: 50%;
+    background-color: var(--color-overlay);
+    color: var(--color-text-primary);
+    font-size: 18px;
+  }
+
+  .movie-dialog__close::before {
+    content: "\00d7";
+    position: static;
+    width: auto;
+    height: auto;
+    border: 0;
+    transform: none;
+  }
 }
 
 .movie-dialog__content h2 {
@@ -300,6 +335,13 @@
     flex: 0 0 280px;
     align-self: flex-start;
     height: auto;
+  }
+
+  /* The close control goes back to a plain top-right ×, clear of the
+     title via its own right margin - no need for the mobile
+     chevron's extra top clearance. */
+  .movie-dialog__content {
+    padding: 20px 20px 56px;
   }
 
   /* The poster sits to the left of the content pane here (row

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -201,60 +201,69 @@
   line-height: 1.5;
 }
 
-.movie-dialog__actions {
-  display: flex;
-  gap: 10px;
-  margin-top: 20px;
-}
-
-.movie-dialog__actions button {
-  flex: 1;
-  height: 44px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background-color: var(--color-info);
-  color: var(--color-text-primary);
-  font-size: 15px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-/* Deliberately understated next to Edit: an outline that fills in
-   only once the user confirms, rather than a same-weight red button
-   sitting right next to the primary action. Floats over the dialog
-   (not the scrollable content pane) so it stays put, bottom-right on
-   both the mobile full page and the desktop floating card. */
+/* Deliberately understated: an outline that fills in only once
+   activated, rather than a solid button competing with the poster
+   for attention. Both float over the dialog (not the scrollable
+   content pane) so they stay put - Edit bottom-left, Delete
+   bottom-right - on both the mobile full page and the desktop
+   floating card. */
+.movie-dialog__edit,
 .movie-dialog__delete {
   position: absolute;
-  right: 16px;
   bottom: 16px;
   z-index: 1;
   overflow: hidden;
   padding: 0 16px;
   height: 36px;
-  border: 1px solid var(--color-danger);
   border-radius: var(--radius-sm);
   background-color: transparent;
-  color: var(--color-danger);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   /* Kept in sync with the fill below: the button's onTransitionEnd
      handler listens for this color transition to know the fill has
-     finished, so a confirm click is only accepted once it's visibly
-     complete. */
+     finished before acting on the click. */
   transition: color 0.7s ease;
 }
 
+.movie-dialog__edit::before,
 .movie-dialog__delete::before {
   content: "";
   position: absolute;
   inset: 0;
   z-index: -1;
-  background-color: var(--color-danger);
   transform: scaleX(0);
-  transform-origin: right;
   transition: transform 0.7s ease;
+}
+
+.movie-dialog__edit {
+  left: 16px;
+  border: 1px solid var(--color-info);
+  color: var(--color-info);
+}
+
+.movie-dialog__edit::before {
+  background-color: var(--color-info);
+  transform-origin: left;
+}
+
+.movie-dialog__edit--active {
+  color: var(--color-text-primary);
+}
+
+.movie-dialog__edit--active::before {
+  transform: scaleX(1);
+}
+
+.movie-dialog__delete {
+  right: 16px;
+  border: 1px solid var(--color-danger);
+  color: var(--color-danger);
+}
+
+.movie-dialog__delete::before {
+  background-color: var(--color-danger);
+  transform-origin: right;
 }
 
 .movie-dialog__delete--confirming {
@@ -263,6 +272,17 @@
 
 .movie-dialog__delete--confirming::before {
   transform: scaleX(1);
+}
+
+/* Edit mode swaps the read-only markup for the shared Form, so it
+   needs the same roomy proportions as the creation dialog rather
+   than the compact read-only card's. */
+.movie-dialog__edit-body {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 @media all and (min-width: 768px) {
@@ -280,6 +300,11 @@
     flex: 0 0 280px;
     align-self: flex-start;
     height: auto;
+  }
+
+  .movie-dialog--editing[open] {
+    width: 80vw;
+    max-height: 60vh;
   }
 }
 

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -147,16 +147,19 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  /* Top clearance for the back chevron (mobile only - see below);
-     bottom clearance so scrolled content never sits under the delete
+  /* Extra clearance so scrolled content never sits under the delete
      button, which floats over the dialog rather than scrolling with
      this pane. */
-  padding: 56px 20px 56px;
+  padding: 20px 20px 56px;
 }
 
 /* Mobile: this reads as a dedicated page rather than a dialog, so
    the control is a plain back chevron - no pill/background - same
-   treatment as the creation and update pages' own back control. */
+   treatment as the creation and update pages' own back control.
+   Positioned against the dialog itself (a sibling of the poster and
+   content panes, not nested in either) so it sits at the actual
+   top-left of the page, over the poster, rather than being pinned to
+   wherever the content pane happens to start below it. */
 .movie-dialog__close {
   position: absolute;
   top: 12px;
@@ -335,13 +338,6 @@
     flex: 0 0 280px;
     align-self: flex-start;
     height: auto;
-  }
-
-  /* The close control goes back to a plain top-right ×, clear of the
-     title via its own right margin - no need for the mobile
-     chevron's extra top clearance. */
-  .movie-dialog__content {
-    padding: 20px 20px 56px;
   }
 
   /* The poster sits to the left of the content pane here (row

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -302,6 +302,15 @@
     height: auto;
   }
 
+  /* The poster sits to the left of the content pane here (row
+     layout), so left:16px (correct on mobile, where content spans
+     the full width below the poster) would otherwise land the
+     button on top of the poster image instead of the content pane
+     it belongs to. */
+  .movie-dialog__edit {
+    left: calc(280px + 16px);
+  }
+
   .movie-dialog--editing[open] {
     width: 80vw;
     max-height: 60vh;

--- a/src/Movie/components/MovieDialog.jsx
+++ b/src/Movie/components/MovieDialog.jsx
@@ -90,14 +90,14 @@ export const MovieDialog = ({
     >
       {movie && (
         <>
+          <button
+            type="button"
+            className="movie-dialog__close"
+            onClick={isEditingMode ? resetEditing : onClose}
+            aria-label={isEditingMode ? "Cancel editing" : "Close"}
+          />
           {isEditingMode ? (
             <div className="movie-dialog__edit-body">
-              <button
-                type="button"
-                className="movie-dialog__close"
-                onClick={resetEditing}
-                aria-label="Cancel editing"
-              />
               <Form
                 initialValues={movie}
                 isUpdate
@@ -137,12 +137,6 @@ export const MovieDialog = ({
                 </div>
               </div>
               <div className="movie-dialog__content">
-                <button
-                  type="button"
-                  className="movie-dialog__close"
-                  onClick={onClose}
-                  aria-label="Close"
-                />
                 <h2 id={titleId}>{movie.title}</h2>
                 {movie.originalTitle && <small>{movie.originalTitle}</small>}
                 {movie.direction && <small>{movie.direction}</small>}

--- a/src/Movie/components/MovieDialog.jsx
+++ b/src/Movie/components/MovieDialog.jsx
@@ -97,9 +97,7 @@ export const MovieDialog = ({
                 className="movie-dialog__close"
                 onClick={resetEditing}
                 aria-label="Cancel editing"
-              >
-                &times;
-              </button>
+              />
               <Form
                 initialValues={movie}
                 isUpdate
@@ -144,9 +142,7 @@ export const MovieDialog = ({
                   className="movie-dialog__close"
                   onClick={onClose}
                   aria-label="Close"
-                >
-                  &times;
-                </button>
+                />
                 <h2 id={titleId}>{movie.title}</h2>
                 {movie.originalTitle && <small>{movie.originalTitle}</small>}
                 {movie.direction && <small>{movie.direction}</small>}

--- a/src/Movie/components/MovieDialog.jsx
+++ b/src/Movie/components/MovieDialog.jsx
@@ -7,19 +7,34 @@ import { useDispatch } from "react-redux";
 import { FormatList } from "Format";
 import { Duration } from "Duration";
 import { Image } from "Core";
-import { remove } from "Movie/Actions";
+import { useMediaQuery } from "Core/useMediaQuery";
+import { remove, update } from "Movie/Actions";
+import { Form } from "Movie/components/Form";
 import { ACTIVE_POSTER_TRANSITION_NAME } from "Movie/components/Movie";
+import { DESKTOP_QUERY } from "Movie/constants";
 
 const assetsUrl = process.env.REACT_APP_API_URL;
 
-export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
+export const MovieDialog = ({
+  dialogRef,
+  movie,
+  isOpen,
+  onClose,
+  onMovieUpdated,
+}) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const titleId = useId();
+  const isDesktop = useMediaQuery(DESKTOP_QUERY);
+
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   // The fill animation must finish before a click actually confirms,
   // otherwise a fast double-click deletes before the user sees it arm.
   const [readyToConfirm, setReadyToConfirm] = useState(false);
+  // Same idea for Edit: the fill plays out before it actually leaves
+  // for edit mode, rather than swapping the instant it's clicked.
+  const [isEnteringEdit, setIsEnteringEdit] = useState(false);
+  const [isEditingMode, setIsEditingMode] = useState(false);
   const [confirmingForMovieId, setConfirmingForMovieId] = useState(movie?.id);
   const deleteButtonRef = useRef(null);
 
@@ -28,11 +43,17 @@ export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
     setReadyToConfirm(false);
   };
 
+  const resetEditing = () => {
+    setIsEnteringEdit(false);
+    setIsEditingMode(false);
+  };
+
   // A movie change (new selection, or the dialog closing) always
-  // means the previous confirmation no longer applies.
+  // means any in-progress confirmation/edit no longer applies.
   if (movie?.id !== confirmingForMovieId) {
     setConfirmingForMovieId(movie?.id);
     resetConfirmation();
+    resetEditing();
   }
 
   useEffect(() => {
@@ -53,7 +74,9 @@ export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
   return createPortal(
     <dialog
       ref={dialogRef}
-      className="movie-dialog"
+      className={
+        isEditingMode ? "movie-dialog movie-dialog--editing" : "movie-dialog"
+      }
       aria-labelledby={movie ? titleId : undefined}
       onCancel={(event) => {
         event.preventDefault();
@@ -67,96 +90,141 @@ export const MovieDialog = ({ dialogRef, movie, isOpen, onClose }) => {
     >
       {movie && (
         <>
-          <div className="movie-dialog__poster">
-            <div className="movie-dialog__poster-backdrop" aria-hidden="true">
-              <Image
-                src={`${assetsUrl}/uploads/${movie.poster}`}
-                alt=""
-                isVisible={isOpen}
-              />
-            </div>
-            <div
-              className="movie-dialog__poster-frame"
-              style={{
-                viewTransitionName: isOpen
-                  ? ACTIVE_POSTER_TRANSITION_NAME
-                  : undefined,
-              }}
-            >
-              <Image
-                src={`${assetsUrl}/uploads/${movie.poster}`}
-                alt={movie.title}
-                isVisible={isOpen}
-              />
-            </div>
-          </div>
-          <div className="movie-dialog__content">
-            <button
-              type="button"
-              className="movie-dialog__close"
-              onClick={onClose}
-              aria-label="Close"
-            >
-              &times;
-            </button>
-            <h2 id={titleId}>{movie.title}</h2>
-            {movie.originalTitle && <small>{movie.originalTitle}</small>}
-            {movie.direction && <small>{movie.direction}</small>}
-            <div className="infos">
-              {movie.duration && <Duration value={movie.duration} />}
-              <FormattedDate value={new Date(movie.releaseDate)} />
-              {movie.formats && <FormatList formats={movie.formats} />}
-            </div>
-            {movie.synopsis && (
-              <p className="movie-dialog__synopsis">{movie.synopsis}</p>
-            )}
-            <div className="movie-dialog__actions">
+          {isEditingMode ? (
+            <div className="movie-dialog__edit-body">
               <button
                 type="button"
-                onClick={() => {
-                  const tile = document.querySelector(
-                    `[data-item-id="${movie.id}"]`
-                  );
-                  if (tile) {
-                    window.sessionStorage.setItem("scrollPos", tile.offsetTop);
-                  }
-                  navigate(`/movies/${movie.id}/update`);
-                }}
+                className="movie-dialog__close"
+                onClick={resetEditing}
+                aria-label="Cancel editing"
               >
-                Edit
+                &times;
               </button>
+              <Form
+                initialValues={movie}
+                isUpdate
+                onSubmit={async (data) => {
+                  const updated = await dispatch(update(data));
+                  onMovieUpdated(updated);
+                  resetEditing();
+                }}
+              />
             </div>
-          </div>
-          <button
-            ref={deleteButtonRef}
-            type="button"
-            className={
-              confirmingDelete
-                ? "movie-dialog__delete movie-dialog__delete--confirming"
-                : "movie-dialog__delete"
-            }
-            onClick={async () => {
-              if (!confirmingDelete) {
-                setConfirmingDelete(true);
-                return;
+          ) : (
+            <>
+              <div className="movie-dialog__poster">
+                <div
+                  className="movie-dialog__poster-backdrop"
+                  aria-hidden="true"
+                >
+                  <Image
+                    src={`${assetsUrl}/uploads/${movie.poster}`}
+                    alt=""
+                    isVisible={isOpen}
+                  />
+                </div>
+                <div
+                  className="movie-dialog__poster-frame"
+                  style={{
+                    viewTransitionName: isOpen
+                      ? ACTIVE_POSTER_TRANSITION_NAME
+                      : undefined,
+                  }}
+                >
+                  <Image
+                    src={`${assetsUrl}/uploads/${movie.poster}`}
+                    alt={movie.title}
+                    isVisible={isOpen}
+                  />
+                </div>
+              </div>
+              <div className="movie-dialog__content">
+                <button
+                  type="button"
+                  className="movie-dialog__close"
+                  onClick={onClose}
+                  aria-label="Close"
+                >
+                  &times;
+                </button>
+                <h2 id={titleId}>{movie.title}</h2>
+                {movie.originalTitle && <small>{movie.originalTitle}</small>}
+                {movie.direction && <small>{movie.direction}</small>}
+                <div className="infos">
+                  {movie.duration && <Duration value={movie.duration} />}
+                  <FormattedDate value={new Date(movie.releaseDate)} />
+                  {movie.formats && <FormatList formats={movie.formats} />}
+                </div>
+                {movie.synopsis && (
+                  <p className="movie-dialog__synopsis">{movie.synopsis}</p>
+                )}
+              </div>
+            </>
+          )}
+          {!isEditingMode && (
+            <button
+              type="button"
+              className={
+                isEnteringEdit
+                  ? "movie-dialog__edit movie-dialog__edit--active"
+                  : "movie-dialog__edit"
               }
-              if (!readyToConfirm) {
-                return;
+              onClick={() => setIsEnteringEdit(true)}
+              onTransitionEnd={(event) => {
+                if (
+                  event.target !== event.currentTarget ||
+                  event.propertyName !== "color"
+                ) {
+                  return;
+                }
+                if (isDesktop) {
+                  setIsEditingMode(true);
+                  return;
+                }
+                const tile = document.querySelector(
+                  `[data-item-id="${movie.id}"]`
+                );
+                if (tile) {
+                  window.sessionStorage.setItem("scrollPos", tile.offsetTop);
+                }
+                navigate(`/movies/${movie.id}/update`);
+              }}
+            >
+              Edit
+            </button>
+          )}
+          {!isEditingMode && (
+            <button
+              ref={deleteButtonRef}
+              type="button"
+              className={
+                confirmingDelete
+                  ? "movie-dialog__delete movie-dialog__delete--confirming"
+                  : "movie-dialog__delete"
               }
-              await dispatch(remove(movie.id, movie.title));
-              onClose();
-            }}
-            onTransitionEnd={(event) => {
-              if (
-                event.target === event.currentTarget &&
-                event.propertyName === "color"
-              ) {
-                setReadyToConfirm(true);
-              }
-            }}
-          >
-            {confirmingDelete ? "Confirm deletion" : "Delete"}
-          </button>
+              onClick={async () => {
+                if (!confirmingDelete) {
+                  setConfirmingDelete(true);
+                  return;
+                }
+                if (!readyToConfirm) {
+                  return;
+                }
+                await dispatch(remove(movie.id, movie.title));
+                onClose();
+              }}
+              onTransitionEnd={(event) => {
+                if (
+                  event.target === event.currentTarget &&
+                  event.propertyName === "color"
+                ) {
+                  setReadyToConfirm(true);
+                }
+              }}
+            >
+              {confirmingDelete ? "Confirm deletion" : "Delete"}
+            </button>
+          )}
         </>
       )}
     </dialog>,

--- a/src/Movie/components/MovieList.jsx
+++ b/src/Movie/components/MovieList.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import "./MovieList.css";
 
 import { Movie } from "Movie/components/Movie";
@@ -9,6 +10,8 @@ const assetsUrl = process.env.REACT_APP_API_URL;
 let timeoutID = null;
 
 export const MovieList = ({ movies }) => {
+  const location = useLocation();
+  const navigate = useNavigate();
   const bottomBoundary = window.innerHeight;
   const [moviesInViewport, setMoviesInViewport] = useState([]);
   const [selectedMovie, setSelectedMovie] = useState(null);
@@ -70,18 +73,24 @@ export const MovieList = ({ movies }) => {
   };
 
   useEffect(() => {
-    const openMovieId = window.sessionStorage.getItem("openMovieId");
+    // Travels through navigation state rather than sessionStorage:
+    // this component never unmounts between the creation dialog
+    // opening and closing (it's the grid visible behind it), so an
+    // effect watching the Redux movie list would fire as soon as the
+    // movie is created - before CreationPage got a chance to record
+    // anything - and never get another chance to notice it later.
+    const openMovieId = location.state?.openMovieId;
     if (!openMovieId) {
       return;
     }
-    window.sessionStorage.removeItem("openMovieId");
 
     const movieToOpen = movies.find((movie) => movie.id === openMovieId);
     if (movieToOpen) {
       selectMovie(movieToOpen);
     }
+    navigate(location.pathname, { replace: true, state: {} });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [movies]);
+  }, [location.state, movies]);
 
   const closeDialog = () => {
     const applyClosedState = () => {

--- a/src/Movie/components/MovieList.jsx
+++ b/src/Movie/components/MovieList.jsx
@@ -129,6 +129,7 @@ export const MovieList = ({ movies }) => {
         movie={selectedMovie}
         isOpen={isDialogOpen}
         onClose={closeDialog}
+        onMovieUpdated={setSelectedMovie}
       />
     </>
   );

--- a/src/Movie/components/MovieList.jsx
+++ b/src/Movie/components/MovieList.jsx
@@ -69,6 +69,20 @@ export const MovieList = ({ movies }) => {
     }
   };
 
+  useEffect(() => {
+    const openMovieId = window.sessionStorage.getItem("openMovieId");
+    if (!openMovieId) {
+      return;
+    }
+    window.sessionStorage.removeItem("openMovieId");
+
+    const movieToOpen = movies.find((movie) => movie.id === openMovieId);
+    if (movieToOpen) {
+      selectMovie(movieToOpen);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [movies]);
+
   const closeDialog = () => {
     const applyClosedState = () => {
       flushSync(() => setIsDialogOpen(false));

--- a/src/Movie/pages/CreationPage.js
+++ b/src/Movie/pages/CreationPage.js
@@ -26,8 +26,12 @@ export const CreationPage = () => {
   const close = () => navigate(HOME_PAGE);
 
   const onSubmit = async (movie) => {
-    const { id } = await dispatch(create(movie));
-    navigate(`/movies/${id}/update`);
+    const created = await dispatch(create(movie));
+    // Home's MovieList picks this up on mount to open the new movie's
+    // own detail dialog/page, the same way it restores scroll
+    // position after coming back from the update page.
+    window.sessionStorage.setItem("openMovieId", created.id);
+    navigate(HOME_PAGE);
   };
 
   return (

--- a/src/Movie/pages/CreationPage.js
+++ b/src/Movie/pages/CreationPage.js
@@ -27,11 +27,15 @@ export const CreationPage = () => {
 
   const onSubmit = async (movie) => {
     const created = await dispatch(create(movie));
-    // Home's MovieList picks this up on mount to open the new movie's
-    // own detail dialog/page, the same way it restores scroll
-    // position after coming back from the update page.
-    window.sessionStorage.setItem("openMovieId", created.id);
-    navigate(HOME_PAGE);
+    // MovieList (already mounted behind this dialog on both mobile
+    // and desktop) picks this up via useLocation to open the new
+    // movie's own detail dialog/page. It has to travel through the
+    // navigation itself rather than sessionStorage: MovieList never
+    // unmounts here, so its effects are watching the Redux movie
+    // list, which updates (via the dispatch above) before we'd get a
+    // chance to write anything to a side channel - by the time it's
+    // written, nothing would be listening for it anymore.
+    navigate(HOME_PAGE, { state: { openMovieId: created.id } });
   };
 
   return (

--- a/src/Movie/pages/UpdatePage.css
+++ b/src/Movie/pages/UpdatePage.css
@@ -1,0 +1,107 @@
+.movie-update-dialog {
+  padding: 0;
+  border: 0;
+  overflow: visible;
+  background: none;
+}
+
+.movie-update-dialog::backdrop {
+  background-color: var(--color-overlay);
+}
+
+.movie-update-dialog[open] {
+  position: fixed;
+  inset: 0;
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
+  animation: movie-update-slide-in 0.3s ease-out;
+}
+
+@keyframes movie-update-slide-in {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+.movie-update-dialog__body {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.movie-update-dialog__close {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 1;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+/* Mobile: a full page, so the control reads as "back" - a plain
+   chevron, matching the creation page's own back control. */
+.movie-update-dialog__close::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  width: 10px;
+  height: 10px;
+  border-left: 2px solid var(--color-text-primary);
+  border-bottom: 2px solid var(--color-text-primary);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+@media all and (min-width: 768px) {
+  .movie-update-dialog[open] {
+    margin: auto;
+    width: 80vw;
+    height: auto;
+    max-height: 60vh;
+    animation: none;
+  }
+
+  .movie-update-dialog__body {
+    border-radius: var(--radius-md);
+    box-shadow: 0 20px 60px var(--color-shadow);
+  }
+
+  .movie-update-dialog__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    top: -16px;
+    left: auto;
+    right: -16px;
+    border-radius: 50%;
+    background-color: rgb(255 255 255 / 12%);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    color: var(--color-text-primary);
+    font-size: 18px;
+  }
+
+  .movie-update-dialog__close::before {
+    content: "\00d7";
+    position: static;
+    width: auto;
+    height: auto;
+    border: 0;
+    transform: none;
+  }
+}

--- a/src/Movie/pages/UpdatePage.js
+++ b/src/Movie/pages/UpdatePage.js
@@ -30,7 +30,12 @@ export const UpdatePage = () => {
     dialogRef.current.showModal();
   }, []);
 
-  const close = () => navigate(HOME_PAGE);
+  // Reopens the movie's own detail dialog/page on Home (the same
+  // mechanism CreationPage uses after creating a movie) instead of
+  // just dropping back to the bare grid, since that's where editing
+  // is normally entered from in the first place.
+  const close = () =>
+    navigate(HOME_PAGE, { state: { openMovieId: params.id } });
 
   return (
     <dialog

--- a/src/Movie/pages/UpdatePage.js
+++ b/src/Movie/pages/UpdatePage.js
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
+import "./UpdatePage.css";
+
+import { HOME_PAGE } from "../../constants";
 import { Form } from "Movie/components/Form";
 import { update } from "Movie/Actions";
 import { fetchMovie } from "Movie/graphql/client";
@@ -9,11 +12,13 @@ import { selectMovies } from "Movie/selectors";
 
 export const UpdatePage = () => {
   const params = useParams();
+  const navigate = useNavigate();
   const movies = useSelector(selectMovies);
-  const dispacth = useDispatch();
+  const dispatch = useDispatch();
   const [movie, setMovie] = useState(
     movies.find((movie) => movie.id === params.id)
   );
+  const dialogRef = useRef();
 
   useEffect(() => {
     if (!movie) {
@@ -21,12 +26,41 @@ export const UpdatePage = () => {
     }
   }, [params, movie]);
 
+  useEffect(() => {
+    dialogRef.current.showModal();
+  }, []);
+
+  const close = () => navigate(HOME_PAGE);
+
   return (
-    <Form
-      key={movie?.id || "loading"}
-      onSubmit={(data) => dispacth(update(data))}
-      initialValues={movie}
-      isUpdate
-    />
+    <dialog
+      ref={dialogRef}
+      className="movie-update-dialog"
+      aria-label="Edit movie"
+      onCancel={(event) => {
+        event.preventDefault();
+        close();
+      }}
+      onClick={(event) => {
+        if (event.target === dialogRef.current) {
+          close();
+        }
+      }}
+    >
+      <button
+        type="button"
+        className="movie-update-dialog__close"
+        onClick={close}
+        aria-label="Close"
+      />
+      <div className="movie-update-dialog__body">
+        <Form
+          key={movie?.id || "loading"}
+          onSubmit={(data) => dispatch(update(data))}
+          initialValues={movie}
+          isUpdate
+        />
+      </div>
+    </dialog>
   );
 };


### PR DESCRIPTION
## Summary
- After creating a movie, the user now lands on that movie's own detail dialog/page (desktop dialog with the grid dimmed behind it, mobile full page) instead of being dropped straight into the edit form. Fixed a race where this wouldn't actually open until a manual page reload, since the grid (`MovieList`) never unmounts behind the creation dialog.
- The detail dialog's Edit control is restyled to match Delete (discreet outline, fills in on click before acting) and now behaves per breakpoint: desktop swaps the dialog in-place to the shared edit form (grid still visible behind it, same proportions as the creation dialog); mobile still navigates to a full update page.
- Editing no longer shows the search/suggestions module - it doesn't apply once you're editing an already-identified movie.
- The Update button is now disabled until the form is both complete (same required-fields validation as creation) *and* actually different from the original values, so a legacy record with a missing field forces you to fill it in, and re-saving with no real changes is blocked.
- `UpdatePage` (the real full-page route, used on mobile and as a direct-URL fallback) now has a back control - it had none before - which returns to the movie's own detail view rather than the bare grid, matching where editing was entered from.
- The detail view's close control is now a back chevron on mobile (it reads as a dedicated page there, not a dialog) positioned against the dialog itself so it sits at the true top-left of the page; desktop keeps the circular × since that context is a genuine dialog over the grid.

## Test plan
- [x] `bunx eslint --max-warnings=0`
- [x] `bun test`
- [x] Verified live on desktop and mobile: creation → detail view (including the race-condition fix, tested via the real "+" → fill → submit flow, not just forced navigation), inline desktop edit mode (enter/cancel/save), mobile edit navigation + back-to-detail, validation blocking incomplete/unchanged saves, close-button placement on both breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)