### PR TITLE
Network feedback: local spinners for Create/Update/Delete and search

### DIFF
--- a/src/Core/components/Spinner.css
+++ b/src/Core/components/Spinner.css
@@ -1,0 +1,15 @@
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spinner-rotate 0.6s linear infinite;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/Core/components/Spinner.jsx
+++ b/src/Core/components/Spinner.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+import "./Spinner.css";
+
+export const Spinner = () => <span className="spinner" aria-hidden="true" />;

--- a/src/Core/index.js
+++ b/src/Core/index.js
@@ -1,10 +1,12 @@
 import { loaderMiddleware } from "./components/Loader";
 import { flashMessageMiddleware } from "./components/FlashMessage";
 import Image from "./components/Image";
+import { Spinner } from "./components/Spinner";
 import { GraphQLClient, authenticateGraphQLClient } from "./GraphQLClient";
 
 export {
   Image,
+  Spinner,
   loaderMiddleware,
   flashMessageMiddleware,
   GraphQLClient,

--- a/src/Movie/Reducer.js
+++ b/src/Movie/Reducer.js
@@ -7,10 +7,12 @@ import {
   MOVIE_CREATION_FAILURE,
   MOVIE_UPDATE_SUCCESS,
   MOVIE_DELETE_SUCCESS,
+  MOVIE_SEARCH_PENDING,
   MOVIE_SEARCH_SUCCESS,
+  MOVIE_SEARCH_FAILURE,
   RESET_PROPOSAL_LIST,
   MOVIE_SYNC,
-  PAGINATE_ITEMS
+  PAGINATE_ITEMS,
 } from "./ActionTypes";
 import { orderBy } from "natural-orderby";
 
@@ -21,7 +23,8 @@ const initialState = {
   limit: parseInt(process.env.REACT_APP_MOVIE_LIST_ITEM_LIMIT),
   isProcessingCreation: false,
   proposals: [],
-  initialized: false
+  isSearching: false,
+  initialized: false,
 };
 
 const movieReducer = (state = initialState, action) => {
@@ -29,75 +32,87 @@ const movieReducer = (state = initialState, action) => {
     case MOVIES_REQUEST_PENDING:
       return {
         ...state,
-        isFetching: true
+        isFetching: true,
       };
     case MOVIES_REQUEST_SUCCESS:
       return {
         ...state,
         isFetching: false,
         items: action.payload.movies,
-        initialized: true
+        initialized: true,
       };
     case MOVIES_REQUEST_FAILURE:
       return {
         ...state,
-        isFetching: false
+        isFetching: false,
       };
     case MOVIE_CREATION_PENDING:
       return {
         ...state,
         isProcessingCreation: true,
-        creationDone: false
+        creationDone: false,
       };
     case MOVIE_CREATION_SUCCESS:
       return {
         ...state,
         items: orderBy([...state.items, action.movie], "title", "asc"),
         isProcessingCreation: false,
-        creationDone: true
+        creationDone: true,
       };
     case MOVIE_CREATION_FAILURE:
       return {
         ...state,
         isProcessingCreation: false,
         creationDone: false,
-        error: action.e
+        error: action.e,
       };
     case MOVIE_DELETE_SUCCESS:
       return {
         ...state,
-        items: state.items.filter(movie => parseInt(movie.id) !== action.id)
+        items: state.items.filter((movie) => parseInt(movie.id) !== action.id),
       };
     case MOVIE_UPDATE_SUCCESS:
       return {
         ...state,
-        items: state.items.map(movie => {
+        items: state.items.map((movie) => {
           if (parseInt(movie.id) === action.movie.id) {
             return action.movie;
           }
 
           return movie;
-        })
+        }),
+      };
+    case MOVIE_SEARCH_PENDING:
+      return {
+        ...state,
+        isSearching: true,
       };
     case MOVIE_SEARCH_SUCCESS:
       return {
         ...state,
-        proposals: action.payload.results
+        proposals: action.payload.results,
+        isSearching: false,
+      };
+    case MOVIE_SEARCH_FAILURE:
+      return {
+        ...state,
+        isSearching: false,
       };
     case RESET_PROPOSAL_LIST:
       return {
         ...state,
-        proposals: []
+        proposals: [],
+        isSearching: false,
       };
     case MOVIE_SYNC:
       return {
         ...state,
-        items: orderBy(action.payload.movies, "title", "asc")
+        items: orderBy(action.payload.movies, "title", "asc"),
       };
     case PAGINATE_ITEMS:
       return {
         ...state,
-        offset: action.payload.offset
+        offset: action.payload.offset,
       };
     default:
       return state;

--- a/src/Movie/components/Form.css
+++ b/src/Movie/components/Form.css
@@ -97,6 +97,9 @@
 }
 
 .movie-form__submit {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 44px;
   border: 0;

--- a/src/Movie/components/Form.jsx
+++ b/src/Movie/components/Form.jsx
@@ -13,7 +13,7 @@ import { useMediaQuery } from "Core/useMediaQuery";
 
 import { search, resetProposalList } from "Movie/Actions";
 import { SuggestionsPanel } from "Movie/components/SuggestionsPanel";
-import { selectProposalList } from "Movie/selectors";
+import { selectIsSearching, selectProposalList } from "Movie/selectors";
 import { DESKTOP_QUERY } from "Movie/constants";
 
 const SEARCH_MIN_LENGTH = 3;
@@ -30,6 +30,7 @@ const areFormatsEqual = (a = [], b = []) => {
 export const Form = ({ onSubmit, initialValues, isUpdate }) => {
   const dispatch = useDispatch();
   const proposals = useSelector(selectProposalList);
+  const isSearching = useSelector(selectIsSearching);
   const [movie, setMovie] = useState(initialValues || {});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isDesktop = useMediaQuery(DESKTOP_QUERY);
@@ -195,6 +196,7 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
       {!isUpdate && (
         <SuggestionsPanel
           proposals={proposals}
+          isSearching={isSearching}
           onSelect={(proposal) => {
             skipNextSearchRef.current = true;
             setMovie({ ...movie, ...proposal });

--- a/src/Movie/components/Form.jsx
+++ b/src/Movie/components/Form.jsx
@@ -8,6 +8,7 @@ import { FormatCheckboxGroup } from "Format/FormatCheckboxGroup";
 
 import { selectFormatList } from "Format/selectors";
 import { CoverInput } from "Core/components/CoverInput";
+import { Spinner } from "Core/components/Spinner";
 import { useMediaQuery } from "Core/useMediaQuery";
 
 import { search, resetProposalList } from "Movie/Actions";
@@ -30,6 +31,7 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
   const dispatch = useDispatch();
   const proposals = useSelector(selectProposalList);
   const [movie, setMovie] = useState(initialValues || {});
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const isDesktop = useMediaQuery(DESKTOP_QUERY);
   // Selecting a suggestion fills title/direction with values long
   // enough to re-trigger the debounced search below; skip that one
@@ -96,9 +98,14 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
     <>
       <form
         className="movie-form"
-        onSubmit={(e) => {
+        onSubmit={async (e) => {
           e.preventDefault();
-          onSubmit(movie);
+          setIsSubmitting(true);
+          try {
+            await onSubmit(movie);
+          } finally {
+            setIsSubmitting(false);
+          }
         }}
       >
         {movie.id && (
@@ -179,9 +186,9 @@ export const Form = ({ onSubmit, initialValues, isUpdate }) => {
           <button
             type="submit"
             className="movie-form__submit"
-            disabled={!isComplete || !hasChanged}
+            disabled={!isComplete || !hasChanged || isSubmitting}
           >
-            {initialValues ? "Update" : "Create"}
+            {isSubmitting ? <Spinner /> : initialValues ? "Update" : "Create"}
           </button>
         </div>
       </form>

--- a/src/Movie/components/Movie.css
+++ b/src/Movie/components/Movie.css
@@ -250,6 +250,9 @@
   position: absolute;
   bottom: 16px;
   z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow: hidden;
   padding: 0 16px;
   height: 36px;

--- a/src/Movie/components/MovieDialog.jsx
+++ b/src/Movie/components/MovieDialog.jsx
@@ -6,7 +6,7 @@ import { useDispatch } from "react-redux";
 
 import { FormatList } from "Format";
 import { Duration } from "Duration";
-import { Image } from "Core";
+import { Image, Spinner } from "Core";
 import { useMediaQuery } from "Core/useMediaQuery";
 import { remove, update } from "Movie/Actions";
 import { Form } from "Movie/components/Form";
@@ -31,6 +31,7 @@ export const MovieDialog = ({
   // The fill animation must finish before a click actually confirms,
   // otherwise a fast double-click deletes before the user sees it arm.
   const [readyToConfirm, setReadyToConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   // Same idea for Edit: the fill plays out before it actually leaves
   // for edit mode, rather than swapping the instant it's clicked.
   const [isEnteringEdit, setIsEnteringEdit] = useState(false);
@@ -41,6 +42,7 @@ export const MovieDialog = ({
   const resetConfirmation = () => {
     setConfirmingDelete(false);
     setReadyToConfirm(false);
+    setIsDeleting(false);
   };
 
   const resetEditing = () => {
@@ -57,7 +59,7 @@ export const MovieDialog = ({
   }
 
   useEffect(() => {
-    if (!confirmingDelete) {
+    if (!confirmingDelete || isDeleting) {
       return undefined;
     }
 
@@ -69,7 +71,7 @@ export const MovieDialog = ({
 
     document.addEventListener("click", handleOutsideClick);
     return () => document.removeEventListener("click", handleOutsideClick);
-  }, [confirmingDelete]);
+  }, [confirmingDelete, isDeleting]);
 
   return createPortal(
     <dialog
@@ -192,6 +194,7 @@ export const MovieDialog = ({
                   ? "movie-dialog__delete movie-dialog__delete--confirming"
                   : "movie-dialog__delete"
               }
+              disabled={isDeleting}
               onClick={async () => {
                 if (!confirmingDelete) {
                   setConfirmingDelete(true);
@@ -200,6 +203,7 @@ export const MovieDialog = ({
                 if (!readyToConfirm) {
                   return;
                 }
+                setIsDeleting(true);
                 await dispatch(remove(movie.id, movie.title));
                 onClose();
               }}
@@ -212,7 +216,13 @@ export const MovieDialog = ({
                 }
               }}
             >
-              {confirmingDelete ? "Confirm deletion" : "Delete"}
+              {isDeleting ? (
+                <Spinner />
+              ) : confirmingDelete ? (
+                "Confirm deletion"
+              ) : (
+                "Delete"
+              )}
             </button>
           )}
         </>

--- a/src/Movie/components/SuggestionsPanel.css
+++ b/src/Movie/components/SuggestionsPanel.css
@@ -56,6 +56,9 @@
 }
 
 .suggestions-panel__placeholder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 0;
   padding: 16px;
   color: var(--color-text-muted);

--- a/src/Movie/components/SuggestionsPanel.jsx
+++ b/src/Movie/components/SuggestionsPanel.jsx
@@ -5,17 +5,20 @@ import "./SuggestionsPanel.css";
 
 import { resetProposalList } from "Movie/Actions";
 import { Proposal } from "Movie/components/Proposal";
+import { Spinner } from "Core/components/Spinner";
 import { useMediaQuery } from "Core/useMediaQuery";
 import { DESKTOP_QUERY } from "Movie/constants";
 
-export const SuggestionsPanel = ({ proposals, onSelect }) => {
+export const SuggestionsPanel = ({ proposals, isSearching, onSelect }) => {
   const dispatch = useDispatch();
   const dialogRef = useRef();
   const isDesktop = useMediaQuery(DESKTOP_QUERY);
   const hasProposals = proposals.length > 0;
   // On desktop the panel is a permanent part of the layout; on mobile
-  // it's a bottom sheet that only appears once there's something to show.
-  const isOpen = isDesktop || hasProposals;
+  // it's a bottom sheet that opens for a result set or to show the
+  // search itself is in progress, and otherwise stays closed (a
+  // search that comes back empty just closes it again).
+  const isOpen = isDesktop || hasProposals || isSearching;
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -61,7 +64,12 @@ export const SuggestionsPanel = ({ proposals, onSelect }) => {
           </button>
         </div>
       )}
-      {hasProposals ? (
+      {isSearching ? (
+        <p className="suggestions-panel__placeholder">
+          <Spinner />
+          Searching…
+        </p>
+      ) : hasProposals ? (
         <ul className="suggestions-panel__list">
           {proposals.map(({ title, releaseDate, direction, poster }) => (
             <Proposal

--- a/src/Movie/selectors.js
+++ b/src/Movie/selectors.js
@@ -1,5 +1,6 @@
 export const selectMovies = (state) => state.movies.items;
 export const selectProposalList = (state) => state.movies.proposals;
+export const selectIsSearching = (state) => state.movies.isSearching;
 export const selectIsFetching = (state) => state.movies.isFetching;
 
 export const selectFormValues = (state) => state.form.movie?.values;


### PR DESCRIPTION
## Summary
- Discovered the existing global loading overlay (`LoaderMiddleware`, watching any `*_PENDING`/`*_SUCCESS`/`*_FAILURE` action) is invisible during create/update/delete/search, since those all happen from inside a native `<dialog>` and `showModal()` renders in the browser's top layer, which always paints above regular DOM regardless of z-index.
- Added a small reusable `Spinner` (`Core/components/Spinner`), CSS-only, using `currentColor` so it adopts whichever button it's placed in.
- `Form`'s submit button (shared by creation, desktop inline edit, and the update page) now tracks its own `isSubmitting` state around the `onSubmit` call and shows the spinner while the request is in flight.
- The delete-confirm button in the movie detail dialog does the same; the outside-click listener that normally disarms the confirmation is now also suppressed while a deletion is in flight, so a stray click during the request can't desync the button's visual state.
- The search suggestions panel now tracks `isSearching` in the movie reducer (off `MOVIE_SEARCH_PENDING`/`SUCCESS`/`FAILURE`, cleared on `RESET_PROPOSAL_LIST` too) and shows a spinner in place of the placeholder/results list while a search is in flight - on mobile this also means the bottom sheet now opens the moment "Search" is tapped instead of staying invisible until results arrive.

## Test plan
- [x] `bunx eslint --max-warnings=0`
- [x] `bun test`
- [x] Verified live: create/delete flows complete successfully end-to-end with the spinner showing; confirmed via `MutationObserver` that the search spinner appears during both the desktop auto-search and the mobile manual "Search" flow (requests are too fast locally to reliably catch in a screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)