### PR TITLE
Virtualize the movie grid

### DIFF
--- a/src/Movie/components/MovieList.css
+++ b/src/Movie/components/MovieList.css
@@ -11,6 +11,25 @@
   min-width: 0;
   content-visibility: auto;
   contain-intrinsic-size: auto 280px;
+  animation: movie-list__item-enter 0.25s ease both;
+}
+
+@keyframes movie-list__item-enter {
+  from {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .movie-list__item {
+    animation: none;
+  }
+}
+
+.movie-list__spacer {
+  grid-column: 1 / -1;
+  height: var(--spacer-height, 0px);
+  list-style: none;
 }
 
 @media all and (min-width: 500px) {

--- a/src/Movie/components/MovieList.jsx
+++ b/src/Movie/components/MovieList.jsx
@@ -1,55 +1,34 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { useLocation, useNavigate } from "react-router-dom";
 import "./MovieList.css";
 
 import { Movie } from "Movie/components/Movie";
 import { MovieDialog } from "Movie/components/MovieDialog";
+import { useVirtualizedGrid } from "Movie/useVirtualizedGrid";
 
 const assetsUrl = process.env.REACT_APP_API_URL;
-let timeoutID = null;
 
 export const MovieList = ({ movies }) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const bottomBoundary = window.innerHeight;
-  const [moviesInViewport, setMoviesInViewport] = useState([]);
+  const {
+    gridRef,
+    mountRange,
+    visibleRange,
+    topSpacerHeight,
+    bottomSpacerHeight,
+  } = useVirtualizedGrid(movies.length);
   const [selectedMovie, setSelectedMovie] = useState(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const dialogRef = useRef();
 
-  const toggleImages = useCallback(() => {
-    clearTimeout(timeoutID);
-    timeoutID = setTimeout(() => {
-      setMoviesInViewport(
-        Array.from(document.querySelectorAll("[data-item-id]")).reduce(
-          (acc, element) => {
-            const { top, bottom } = element.getBoundingClientRect();
-            if (bottom > 0 && top < bottomBoundary) {
-              acc = [...acc, element.dataset.itemId];
-            }
-
-            return acc;
-          },
-          []
-        )
-      );
-    }, 250);
-  }, [setMoviesInViewport, bottomBoundary]);
-
   useEffect(() => {
-    toggleImages();
-    window.addEventListener("scroll", toggleImages);
-
     if (window.sessionStorage.getItem("scrollPos")) {
       window.scrollTo(0, parseInt(window.sessionStorage.getItem("scrollPos")));
       window.sessionStorage.removeItem("scrollPos");
     }
-
-    return () => {
-      window.removeEventListener("scroll", toggleImages);
-    };
-  }, [toggleImages]);
+  }, []);
 
   const selectMovie = async (movie) => {
     // Make sure the dialog's poster is already decoded before the
@@ -110,19 +89,36 @@ export const MovieList = ({ movies }) => {
 
   return (
     <>
-      <ul className="movie-list">
-        {movies.map((movie) => {
+      <ul className="movie-list" ref={gridRef}>
+        {topSpacerHeight > 0 && (
+          <li
+            className="movie-list__spacer"
+            aria-hidden="true"
+            style={{ "--spacer-height": `${topSpacerHeight}px` }}
+          />
+        )}
+        {movies.slice(mountRange.start, mountRange.end).map((movie, i) => {
+          const index = mountRange.start + i;
           return (
             <Movie
               key={movie.id}
               movie={movie}
-              showImage={moviesInViewport.includes(movie.id)}
+              showImage={
+                index >= visibleRange.start && index < visibleRange.end
+              }
               isActive={selectedMovie?.id === movie.id}
               isDialogOpen={isDialogOpen}
               onSelect={() => selectMovie(movie)}
             />
           );
         })}
+        {bottomSpacerHeight > 0 && (
+          <li
+            className="movie-list__spacer"
+            aria-hidden="true"
+            style={{ "--spacer-height": `${bottomSpacerHeight}px` }}
+          />
+        )}
       </ul>
       <MovieDialog
         dialogRef={dialogRef}

--- a/src/Movie/useVirtualizedGrid.js
+++ b/src/Movie/useVirtualizedGrid.js
@@ -1,0 +1,161 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+const OVERSCAN_ROWS = 3;
+
+// Used only until the grid has rendered a real item to measure - matches
+// the contain-intrinsic-size hint in MovieList.css so the very first
+// frame guesses a sane row count instead of mounting everything.
+const BOOTSTRAP_ITEM_HEIGHT = 280;
+const BOOTSTRAP_ROW_GAP = 10;
+const BOOTSTRAP_COLUMNS = 2;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+// Mounts only the grid rows near the viewport (plus a small overscan
+// buffer) instead of every item at once, and narrows that further down
+// to a strictly-visible range for swapping in real poster images. Row
+// height is measured off an actual rendered item rather than assumed,
+// since it's driven by CSS (aspect-ratio + responsive column width).
+export const useVirtualizedGrid = (itemCount) => {
+  const gridRef = useRef(null);
+  const [layout, setLayout] = useState({
+    columns: 0,
+    itemHeight: 0,
+    rowGap: 0,
+  });
+  const [mountRange, setMountRange] = useState({ start: 0, end: 0 });
+  const [visibleRange, setVisibleRange] = useState({ start: 0, end: 0 });
+
+  const measured = layout.itemHeight > 0;
+  const columns = layout.columns || BOOTSTRAP_COLUMNS;
+  const itemHeight = measured ? layout.itemHeight : BOOTSTRAP_ITEM_HEIGHT;
+  const rowGap = measured ? layout.rowGap : BOOTSTRAP_ROW_GAP;
+
+  const computeRanges = useCallback(() => {
+    const gridEl = gridRef.current;
+    if (!gridEl || itemCount === 0) {
+      setMountRange({ start: 0, end: 0 });
+      setVisibleRange({ start: 0, end: 0 });
+      return;
+    }
+
+    const rowPitch = itemHeight + rowGap;
+    const totalRows = Math.ceil(itemCount / columns);
+    const gridTop = gridEl.getBoundingClientRect().top + window.scrollY;
+    const viewTop = window.scrollY;
+    const viewBottom = viewTop + window.innerHeight;
+    const clampRow = (row) => clamp(row, 0, totalRows - 1);
+
+    const firstVisibleRow = clampRow(
+      Math.floor((viewTop - gridTop) / rowPitch)
+    );
+    const lastVisibleRow = clampRow(
+      Math.ceil((viewBottom - gridTop) / rowPitch) - 1
+    );
+    const firstMountRow = clampRow(firstVisibleRow - OVERSCAN_ROWS);
+    const lastMountRow = clampRow(lastVisibleRow + OVERSCAN_ROWS);
+
+    setVisibleRange({
+      start: firstVisibleRow * columns,
+      end: Math.min(itemCount, (lastVisibleRow + 1) * columns),
+    });
+    setMountRange({
+      start: firstMountRow * columns,
+      end: Math.min(itemCount, (lastMountRow + 1) * columns),
+    });
+  }, [itemCount, columns, itemHeight, rowGap]);
+
+  // Deliberately not throttled through requestAnimationFrame: rAF
+  // callbacks get suspended for backgrounded/inactive tabs, which would
+  // freeze the mounted window mid-scroll. computeRanges is cheap (one
+  // getBoundingClientRect call, no DOM scanning), so running it on every
+  // scroll/resize event is fine.
+  const scheduleCompute = computeRanges;
+
+  // Column count: read back from the grid itself (auto-fill resolves it
+  // from the container width) rather than duplicating the breakpoints
+  // from MovieList.css here.
+  useLayoutEffect(() => {
+    const gridEl = gridRef.current;
+    if (!gridEl) return;
+
+    const measureColumns = () => {
+      const trackCount = getComputedStyle(gridEl)
+        .gridTemplateColumns.split(" ")
+        .filter(Boolean).length;
+
+      setLayout((prev) =>
+        prev.columns === trackCount ? prev : { ...prev, columns: trackCount }
+      );
+    };
+
+    measureColumns();
+    const observer = new ResizeObserver(measureColumns);
+    observer.observe(gridEl);
+    return () => observer.disconnect();
+  }, []);
+
+  // Row pitch: measured off the first mounted item, re-targeted whenever
+  // the mounted window (or the underlying item count/order) changes.
+  useLayoutEffect(() => {
+    const gridEl = gridRef.current;
+    const itemEl = gridEl?.querySelector("[data-item-id]");
+    if (!gridEl || !itemEl) return;
+
+    const measureRow = () => {
+      const nextRowGap = parseFloat(getComputedStyle(gridEl).rowGap) || 0;
+      const nextItemHeight = Math.round(itemEl.getBoundingClientRect().height);
+      if (nextItemHeight <= 0) return;
+
+      setLayout((prev) =>
+        prev.itemHeight === nextItemHeight && prev.rowGap === nextRowGap
+          ? prev
+          : { ...prev, itemHeight: nextItemHeight, rowGap: nextRowGap }
+      );
+    };
+
+    measureRow();
+    const observer = new ResizeObserver(measureRow);
+    observer.observe(itemEl);
+    return () => observer.disconnect();
+  }, [mountRange.start, itemCount]);
+
+  // Layout effect, not a plain effect: this must settle (together with
+  // the column/row measurements above) before the browser's first paint,
+  // otherwise the grid flashes empty for a frame while state converges.
+  useLayoutEffect(() => {
+    computeRanges();
+  }, [computeRanges]);
+
+  useEffect(() => {
+    window.addEventListener("scroll", scheduleCompute, { passive: true });
+    window.addEventListener("resize", scheduleCompute);
+    return () => {
+      window.removeEventListener("scroll", scheduleCompute);
+      window.removeEventListener("resize", scheduleCompute);
+    };
+  }, [scheduleCompute]);
+
+  const spacerHeight = (rows) =>
+    rows > 0 ? rows * itemHeight + Math.max(0, rows - 1) * rowGap : 0;
+
+  const topRows = Math.floor(mountRange.start / columns);
+  const bottomRows = Math.max(
+    0,
+    Math.ceil(itemCount / columns) - Math.ceil(mountRange.end / columns)
+  );
+
+  return {
+    gridRef,
+    mountRange,
+    visibleRange,
+    topSpacerHeight: spacerHeight(topRows),
+    bottomSpacerHeight: spacerHeight(bottomRows),
+  };
+};


### PR DESCRIPTION
## Summary
- Only mounts grid rows near the viewport (plus a small overscan buffer) instead of every movie at once, so the grid no longer sits blank for seconds while hundreds of items mount.
- Row height and column count are measured off the actual rendered grid (`ResizeObserver` + computed style) instead of duplicating the CSS breakpoints in JS.
- Extends the existing per-image visibility toggle: it's now derived arithmetically from the same virtualization state instead of scanning every DOM node's bounding rect on each scroll tick.

## Test plan
- [x] `bun run build` and `eslint` pass
- [x] Verified against the real dataset (850 movies): mounted DOM nodes drop from 850 to ~36-42 at any scroll position, and stay bounded while scrolling
- [x] Confirmed the mounted/visible windows shift correctly with real scroll interaction
- [x] Movie dialog open/close still works
- [x] Responsive column recompute verified (6 columns desktop, 2 columns mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)